### PR TITLE
Require human readable description

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Require human readable description to define a feature toggle
+* Add rake task that outputs all the feature toggles states (on, off, ? -
+  unknown due to Compex Rule), keys, and human readable descritpions
+
 #### v0.1.0
 
 * Add concept of Groups as a provided rule

--- a/README.md
+++ b/README.md
@@ -25,35 +25,150 @@ Or install it yourself as:
 
     $ gem install togls
 
-## Usage
+## Basic Usage
 
-### Setup
+The basic usage of `Togls` is outlined below.
 
-The default behaviour for any feature that has not been defined that is accessed is to default to false.
+### Defining Feature Toggles
+
+The first thing to do to use `Togls` is to define your feature toggles. The
+following is an example of how you might define your feature toggles. It is
+recommended this live in its own file. In Rails projects we recommend putting
+it in `config/initializers/togls_features.rb`.
 
 ```ruby
 Togls.features do
   # Set this feature to always be on
-  feature(:pop_up_login_form).on 
+  feature(:pop_up_login_form, "use the pop up login instead of normal login").on 
   # Set this feature to always be off
-  feature(:send_follup_email).off
+  feature(:send_follup_email, "send the follow up email").off
   # Create a group rule
   rule = Togls::Rules::Group.new(["user@email.com"])
-  feature(:new_contact_form).on(rule)
+  feature(:new_contact_form, "use new contact form instead of old one").on(rule)
 end
 ```
 
-### Evaluate
+### Evaluating Feature Toggles
+
+Once you have defined your feature toggles. The next thing you would likely
+want to do is conditionally control something based on them. The following are
+a few examples of how you would do this given the above.
 
 ```ruby
+if Togls.feature(:pop_up_login_form).on?
+  # Use pop up login form
+else
+  # Use normal non-pop up login form
+end
+
+if Togls.feature(:send_follup_email).on?
+  # send the follow up email
+end
+
 if Togls.feature(:new_contact_form).on?("user@email.com")
-  # Do my awesome feature
+  # Use new contact form
+else
+  # Use old contact form
 end
 ```
+
+**Note:** The default behaviour for any feature that has not been defined that
+is accessed is to default to false.
+
+### Output Feature Toggles
+
+One other use case that we support as part of the *Basic Usage* is outputing all
+of the features in your system and their respective, **states** (`on`, `off`, `?` -
+unkown due to *Complex Rule*), **key**, and **human readable descrption**.
+
+We provide this functionality via a [rake](https://github.com/ruby/rake) task.
+
+#### Load rake task
+
+To use it you must first load the provided
+[rake](https://github.com/ruby/rake) file. This can be done in a number of
+different ways.
+
+##### Load rake task in another gem
+
+To use it in another gem you can use the following in the second gem's
+`Rakefile`.
+
+```ruby
+spec = Gem::Specification.find_by_name 'togls'
+load "#{spec.gem_dir}/lib/tasks/togls.rake"
+```
+
+**Note:** The features must be defined and loaded before calling this task or
+it will error out informing you that you need to define your features first.
+
+##### Load rake task in a Rails app
+
+To use the it in a Rails app you can do so by adding the following to the
+`Rakefile`.
+
+```ruby
+namespace :togls do
+  task :features => [:environment] do
+  end
+end
+
+spec = Gem::Specification.find_by_name 'togls'
+load "#{spec.gem_dir}/lib/tasks/togls.rake"
+```
+
+**Note:** The first hunk where it defines an empty `togls:features` tasks is
+important in Rails because it takes advantage of
+[rake](https://github.com/ruby/rake) task stacking and calls out the Rails
+environment as a dependency. That way before the `togls:feature` task is
+executed the `config/initializers/togls_features.rb` file is loaded which
+defines the feature toggles.
+
+#### Verify rake task loaded
+
+To verify that the rake task is loaded you can run `rake -T` and you should
+see something similar to the following in the output.
+
+```text
+rake togls:features                     # Output all features including status (on, off, ? - unknown due to complex rule), ke...
+```
+
+#### Run the rake task
+
+Once you have verified the task is loaded and available you can run it as
+follows.
+
+```shell
+rake togls:features
+```
+
+The following is an example of what the output might look like if you defined
+a few test features.
+
+```text
+ on - :test1 - test 1 feature
+off - :test2 - test 2 feature
+off - :test3 - test 3 feature
+```
+
+## Advanced Usage
+
+Below is a breakdown of some of the more advanced features of `Togls` which
+aren't necessary in order to use it for basic feature toggles.
 
 ### Custom Rules
 
-A simple rule can be defined by created a rule object and passing a block
+`Togls` is specifically architected on top of a generic concept of a
+`Togls::Rule`.  This empowers the users to define any custome rules they would
+like and use them to control their feature toggles.  For example, you could
+use them to do A/B testing, define alpha test group, give a percentage of a
+user base a feature, etc.
+
+### Simple Rules
+
+A simple rule can be defined by creating a rule object and passing a block. In
+the following example any feature using the `gmail_rule` would only be on if
+the given `target` contained `gmail.com` at the end of the `target`.
 
 ```ruby
 # Only allow users with email addresses at gmail.com
@@ -64,7 +179,40 @@ Togls.features do
 end
 ```
 
-To implement a more complex rule a new rule object can be defined under Togls::Rules that implements the run method and returns a boolean. When a feature is defined, the rule will be added to the feature object and the run method called with whatever target is passed.
+### Complex Rules
+
+To implement a more complex rule, a new rule object can be defined under
+`Togls::Rules` that abides by the following.
+
+- inherits from `Togls::Rule` or a decendent of it
+- has an instance method named `run` that takes either a default value
+  parameter of `target` or a required paramter of `target`.
+
+    ```ruby
+    def run(target = 'foo')
+    ...
+    end
+    
+    # or
+
+    def run(target)
+    ...
+    end
+    ```
+
+- has the instance method named `run` return a boolean value identifying if
+  that feature should be on(`true`)/off(`false`) given the `target`.
+
+Thats it!
+
+#### Example Complex Rule
+
+Internally `Togls` uses these *Complex Rules* to provide functionality and
+will evolve to contain more official rules over time. If you have a generic
+*Complex Rule* you think should be part of `Togls` please make a pull request.
+
+A prime example of a *Complex Rule* provided by `Togls` is the
+`Togls::Rules::Group` rule. You can see it below.
 
 ```ruby
 module Togls
@@ -81,6 +229,25 @@ module Togls
   end
 end
 ```
+
+Lets take a closer look at exactly what is going on here.
+
+- it is inheriting from the `Togls::Rule` class which meets one of the minimum
+  requirements for a rule.
+- its defines constructor takes an array identifiers and stores them. These
+  identifiers could be id numbers, email address, etc. **Note:** This
+  constructor is completely different than that of `Togls::Rule`. This
+  is fine because it is **not** a requirements that the constructor match.
+- its `run` method returns a boolean value identifying if the feature should
+  be on(`true`)/off(`false`) for the given `target`. It does so by identifying
+  if the array passed in at construction time `include?` the given `target`.
+  This meets one of the minimum requirement for a rule.
+- its `run` method signature requires a `target`. This meets a minimum
+  requirement for a rule as well. It also makes sense in the case of group
+  based rule as it has to have something to compare against the group.
+
+*Complex Rules* are a simple yet extremely power concept that you shouldn't
+hesitate to use.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ aren't necessary in order to use it for basic feature toggles.
 ### Custom Rules
 
 `Togls` is specifically architected on top of a generic concept of a
-`Togls::Rule`.  This empowers the users to define any custome rules they would
+`Togls::Rule`.  This empowers the users to define any custom rules they would
 like and use them to control their feature toggles.  For example, you could
 use them to do A/B testing, define alpha test group, give a percentage of a
 user base a feature, etc.

--- a/lib/tasks/togls.rake
+++ b/lib/tasks/togls.rake
@@ -1,0 +1,7 @@
+namespace :togls do
+  task :features do
+    Togls.features.each do |key, feature|
+      puts feature.to_s
+    end
+  end
+end

--- a/lib/tasks/togls.rake
+++ b/lib/tasks/togls.rake
@@ -1,4 +1,5 @@
 namespace :togls do
+  desc "Output all features including status (on, off, ? - unknown due to complex rule), key, description"
   task :features do
     Togls.features.each do |key, feature|
       puts feature.to_s

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -1,4 +1,5 @@
 require "togls/version"
+require "togls/errors"
 require "togls/feature_registry"
 require "togls/feature"
 require "togls/rule"
@@ -7,7 +8,15 @@ require "logger"
 
 module Togls
   def self.features(&features)
-    @feature_registry = FeatureRegistry.create(&features)
+    if !features.nil?
+      @feature_registry = FeatureRegistry.create(&features)
+    else
+      if @feature_registry.nil?
+        raise Togls::NoFeaturesError, "Need to define features before you can get them"
+      else
+        @feature_registry.registry
+      end
+    end
   end
   
   def self.feature(key)

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -1,0 +1,3 @@
+module Togls
+  class NoFeaturesError < StandardError; end
+end

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -10,17 +10,29 @@ module Togls
 
     def on(rule = nil)
       if rule.nil?
-        rule = Rule.new { true }
+        rule = Togls::Rules::Boolean.new(true)
       end
       @rule = rule 
+      self
     end
 
     def off
-      @rule = Rule.new { false }
+      @rule = Togls::Rules::Boolean.new(false)
+      self
     end
 
     def on?(target = nil)
       @rule.run(target)
+    end
+
+    def to_s
+      if @rule.is_a?(Togls::Rules::Boolean)
+        display_value = @rule.run ? ' on' : 'off'
+      else
+        display_value = '  ?'
+      end
+
+      "#{display_value} - #{@key.inspect} - #{@description}"
     end
   end
 end

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -1,9 +1,10 @@
 module Togls
   class Feature
-    attr_reader :key
+    attr_reader :key, :description
 
-    def initialize(key)
+    def initialize(key, description)
       @key = key
+      @description = description
       off
     end
 

--- a/lib/togls/feature_registry.rb
+++ b/lib/togls/feature_registry.rb
@@ -2,7 +2,7 @@ module Togls
   class FeatureRegistry
     def initialize
       @registry = {}
-      @default_feature = Feature.new(:default).tap {|f| f.on(Rule.new { false }) }
+      @default_feature = Feature.new(:default, "the official default feature").tap {|f| f.on(Rule.new { false }) }
     end
 
     def self.create(&features)
@@ -11,8 +11,8 @@ module Togls
       registry
     end
 
-    def feature(tag)
-      @registry[tag.to_sym] = Feature.new(tag.to_sym)
+    def feature(tag, desc)
+      @registry[tag.to_sym] = Feature.new(tag.to_sym, desc)
     end
 
     def get(key)

--- a/lib/togls/feature_registry.rb
+++ b/lib/togls/feature_registry.rb
@@ -21,5 +21,9 @@ module Togls
         @default_feature
       end
     end
+
+    def registry
+      @registry
+    end
   end
 end

--- a/lib/togls/rules.rb
+++ b/lib/togls/rules.rb
@@ -1,3 +1,4 @@
+require 'togls/rules/boolean'
 require 'togls/rules/group'
 
 module Togls

--- a/lib/togls/rules/boolean.rb
+++ b/lib/togls/rules/boolean.rb
@@ -1,0 +1,13 @@
+module Togls
+  module Rules
+    class Boolean < Rule
+      def initialize(bool)
+        @bool = bool
+      end
+
+      def run(target = nil)
+        return @bool
+      end
+    end
+  end
+end

--- a/spec/features/togls_spec.rb
+++ b/spec/features/togls_spec.rb
@@ -44,4 +44,22 @@ describe "Togl feature creation" do
     expect(Togls.feature(:test).on?("someone")).to eq(true)
     expect(Togls.feature(:test).on?("someone_else")).to eq(false)
   end
+
+  it "outputs all the features" do
+    Togls.features do
+      feature(:test1, "test1 readable description").on
+      feature(:test2, "test2 readable description").off
+      feature(:test3, "test3 readable description")
+      feature(:test4, "test4 readable description").on(Togls::Rule.new { true })
+    end
+
+    require 'rake'
+    load 'lib/tasks/togls.rake'
+
+    expect { Rake::Task["togls:features"].invoke }.to output(%q{ on - :test1 - test1 readable description
+off - :test2 - test2 readable description
+off - :test3 - test3 readable description
+  ? - :test4 - test4 readable description
+}).to_stdout
+  end
 end

--- a/spec/features/togls_spec.rb
+++ b/spec/features/togls_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 describe "Togl feature creation" do
   it "creates a new feature toggled on" do
     Togls.features do
-      feature(:test).on
+      feature(:test, "some human readable description").on
     end
 
     expect(Togls.feature(:test).on?).to eq(true)
@@ -11,7 +11,7 @@ describe "Togl feature creation" do
 
   it "creates a new feature toggled off" do
     Togls.features do
-      feature(:test).off
+      feature(:test, "some human readable description").off
     end
 
     expect(Togls.feature(:test).on?).to eq(false)
@@ -20,7 +20,7 @@ describe "Togl feature creation" do
   it "defaults to false when a feature is not defined" do
     allow(Togls.logger).to receive(:warn)
     Togls.features do
-      feature(:test).on
+      feature(:test, "some human readable description").on
     end
 
     expect(Togls.feature(:not_defined).on?).to eq(false)
@@ -29,7 +29,7 @@ describe "Togl feature creation" do
   it "creates a new feature with a rule" do
     Togls.features do
       rule = Togls::Rule.new { |v| !v }
-      feature(:test).on(rule)
+      feature(:test, "some human readable description").on(rule)
     end
 
     expect(Togls.feature(:test).on?(true)).to eq(false)
@@ -38,7 +38,7 @@ describe "Togl feature creation" do
   it "creates a new feature with a group" do
     Togls.features do
       rule = Togls::Rules::Group.new(["someone"])
-      feature(:test).on(rule)
+      feature(:test, "some human readable description").on(rule)
     end
 
     expect(Togls.feature(:test).on?("someone")).to eq(true)

--- a/spec/lib/togls/feature_registry_spec.rb
+++ b/spec/lib/togls/feature_registry_spec.rb
@@ -87,4 +87,14 @@ describe Togls::FeatureRegistry do
       end
     end
   end
+
+  describe "#registry" do
+    it "returns the registry of feature objects" do
+      feature_double = double('feature')
+      feature_registry = Togls::FeatureRegistry.create do
+      end
+      feature_registry.instance_variable_set(:@registry, { :test => feature_double })
+      expect(feature_registry.registry).to eq({ :test => feature_double })
+    end
+  end
 end

--- a/spec/lib/togls/feature_registry_spec.rb
+++ b/spec/lib/togls/feature_registry_spec.rb
@@ -40,32 +40,35 @@ describe Togls::FeatureRegistry do
 
   describe "#feature" do
     before do
-      allow(Togls::Feature).to receive(:new).with(:default).and_return(spy)
+      allow(Togls::Feature).to receive(:new).with(:default, "the official default feature").and_return(spy)
     end
 
     it "creates a new feature object with the passed key" do
-      expect(Togls::Feature).to receive(:new).with(key)
-      subject.feature(key)
+      desc = double('feature desc')
+      expect(Togls::Feature).to receive(:new).with(key, desc)
+      subject.feature(key, desc)
     end
 
     it "adds the feature to the registry" do
+      desc = double('feature desc')
       feature = double('feature')
-      allow(Togls::Feature).to receive(:new).with(key).and_return(feature)
-      subject.feature(key)
+      allow(Togls::Feature).to receive(:new).with(key, desc).and_return(feature)
+      subject.feature(key, desc)
       expect(subject.instance_variable_get(:@registry)[key]).to eq(feature)
     end
   end
 
   describe "#get" do
     before do
-      allow(Togls::Feature).to receive(:new).with(:default).and_return(spy)
+      allow(Togls::Feature).to receive(:new).with(:default, "the official default feature").and_return(spy)
     end
 
     context "when feature exists in registry" do
       it "returns the feature identified by key" do
+        desc = double('feature desc')
         feature = double('feature')
-        allow(Togls::Feature).to receive(:new).with(key).and_return(feature)
-        subject.feature(key)
+        allow(Togls::Feature).to receive(:new).with(key, desc).and_return(feature)
+        subject.feature(key, desc)
         expect(subject.get(key)).to eq(feature)
       end
     end

--- a/spec/lib/togls/feature_spec.rb
+++ b/spec/lib/togls/feature_spec.rb
@@ -1,11 +1,15 @@
 require_relative '../../spec_helper'
 
 describe Togls::Feature do
-  subject { Togls::Feature.new(:key) }
+  subject { Togls::Feature.new(:key, "some description") }
 
   describe "#initialize" do
     it "assigns the passed key" do
       expect(subject.key).to eq(:key)
+    end
+
+    it "assigns the description" do
+      expect(subject.description).to eq("some description")
     end
 
     it "defaults to off" do
@@ -55,6 +59,12 @@ describe Togls::Feature do
         subject.on
         expect(subject.on?).to eq(true)
       end
+    end
+  end
+
+  describe "#description" do
+    it "returns the description" do
+      expect(subject.description).to eq("some description")
     end
   end
 end

--- a/spec/lib/togls/feature_spec.rb
+++ b/spec/lib/togls/feature_spec.rb
@@ -29,6 +29,11 @@ describe Togls::Feature do
       subject.on
       expect(subject.instance_variable_get(:@rule).run).to eq(true)
     end
+
+    it "returns its associated feature object" do
+      retval = subject.on
+      expect(retval).to eq(subject)
+    end
   end
 
   describe "#off" do
@@ -42,6 +47,11 @@ describe Togls::Feature do
     it "sets the feature rule to false" do
       subject.off
       expect(subject.instance_variable_get(:@rule).run).to eq(false)
+    end
+
+    it "returns its associated feature object" do
+      retval = subject.off
+      expect(retval).to eq(subject)
     end
   end
 
@@ -65,6 +75,23 @@ describe Togls::Feature do
   describe "#description" do
     it "returns the description" do
       expect(subject.description).to eq("some description")
+    end
+  end
+
+  describe "#to_s" do
+    context "when based on boolean rule" do
+      it "returns a human readable string representation of the feature including value" do
+        feature = Togls::Feature.new(:key, "some description").on(Togls::Rules::Boolean.new(true))
+        expect(feature.to_s).to eq(" on - :key - some description")
+      end
+    end
+
+    context "when NOT based on boolean rule" do
+      it "returns a human readable string representation of the feature with an unknown value" do
+        rule = Togls::Rule.new { |v| !v }
+        feature = Togls::Feature.new(:another_key, "another description").on(rule)
+        expect(feature.to_s).to eq("  ? - :another_key - another description")
+      end
     end
   end
 end

--- a/spec/lib/togls/rules/boolean_spec.rb
+++ b/spec/lib/togls/rules/boolean_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../../spec_helper'
+
+describe Togls::Rules::Boolean do
+  describe "#initialize" do
+    it "stores the passed boolean" do
+      bool = double('bool')
+      group = Togls::Rules::Boolean.new(bool)
+      expect(group.instance_variable_get(:@bool)).to eq(bool)
+    end
+  end
+
+  describe "#run" do
+    it "returns the provided boolean value" do
+      bool_rule = Togls::Rules::Boolean.new(true)
+      expect(bool_rule.run).to eq(true)
+    end
+  end
+end

--- a/spec/lib/togls_spec.rb
+++ b/spec/lib/togls_spec.rb
@@ -2,10 +2,47 @@ require_relative '../spec_helper'
 
 describe Togls do
   describe ".features" do
-    it "creates a new feature registry with passed block" do
-      b = Proc.new {}
-      expect(Togls::FeatureRegistry).to receive(:create).and_yield(&b)
-      Togls.features(&b)
+    context "when features have NOT been defined" do
+      context "when given a block" do
+        it "creates a new feature registry with passed block" do
+          b = Proc.new {}
+          expect(Togls::FeatureRegistry).to receive(:create).and_yield(&b)
+          Togls.features(&b)
+        end
+      end
+      
+      context "when NOT given a block" do
+        it "raises an error telling the user they must first define features" do
+          expect { Togls.features }.to raise_error(Togls::NoFeaturesError)
+        end
+      end
+    end
+
+    context "when features HAVE been defined" do
+      before do
+        Togls.features do
+          feature(:test1, "test1 readable description").on
+          feature(:test2, "test2 readable description").off
+          feature(:test3, "test3 readable description")
+        end
+      end
+
+      context "when given a block" do
+        it "replaces the feature registry with a new feature registry" do
+          b = Proc.new {}
+          expect(Togls::FeatureRegistry).to receive(:create).and_yield(&b)
+          Togls.features(&b)
+        end
+      end
+
+      context "when NOT given a block" do
+        it "returns hash of feature objects identified by their key" do
+          features = Togls.features
+          expect(features[:test1].description).to eq("test1 readable description")
+          expect(features[:test2].description).to eq("test2 readable description")
+          expect(features[:test3].description).to eq("test3 readable description")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This pull request includes the following significant changes.

- It changes the define feature toggle api to **require** a human readable description. I did this as an opinionated attempt at getting people to actually describe what their feature toggles are for so that after they have been around for a bit people can still understand them.
- Added a rake task to output all the features toggles in the system **state** (`on`, `off`, `?` - unknown due to *Complex Rule*), **key**, and **human readable description**. I saw this being useful for reviewing a systems feature toggles from time to time.
- Revamp of the `README.md` to include new description based features, but also to better explain the concept of Rules and their requirements.

This should resolve issue #5.