### PR TITLE
Eliminate a useless `tap()` call

### DIFF
--- a/lib/togls/feature_registry.rb
+++ b/lib/togls/feature_registry.rb
@@ -2,7 +2,7 @@ module Togls
   class FeatureRegistry
     def initialize
       @registry = {}
-      @default_feature = Feature.new(:default, "the official default feature").tap {|f| f.on(Rule.new { false }) }
+      @default_feature = Feature.new(:default, "the official default feature").on(Rule.new { false })
     end
 
     def self.create(&features)


### PR DESCRIPTION
I eliminated the `tap()` call in this because the `Feature#on` method
returns `self`, which is the instance of the `Feature` itself.
Therefore, it would be the same as what the `tap()` call is doing. I
suspect this was done maybe before the `on()` method returned `self`.
Either way, now it seems useless to use a `tap()` call there.

You can see the `on()` definition return `self` at the following.

https://github.com/codebreakdown/togls/blob/master/lib/togls/feature.rb#L16