### PR TITLE
Make default boolean rule klass configurable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ versions, as well as provide a rough history.
 #### Next Release
 
 * Rename var in `FeatureRegistry.create` avoid confusion with overloaded name
+* Make default boolean rule class configurable
 
 #### v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ off - :test3 - test 3 feature
 Below is a breakdown of some of the more advanced features of `Togls` which
 aren't necessary in order to use it for basic feature toggles.
 
+### Override Default Boolean Rule
+
+`Togls` allows you to override the Rule class that is used for default boolean
+values. The default boolean rule class is `Togls::Rules::Boolean`.
+
+If you want to use a different default boolean rule you can override the
+default using the following:
+
+```ruby
+Togls.default_boolean_rule_klass = WhateverBooleanRuleKlassYouWant
+```
+
 ### Custom Rules
 
 `Togls` is specifically architected on top of a generic concept of a

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -7,6 +7,18 @@ require "togls/rules"
 require "logger"
 
 module Togls
+  def self.default_boolean_rule_klass
+    if @default_boolean_rule_klass
+      return @default_boolean_rule_klass
+    else
+      return Togls::Rules::Boolean
+    end
+  end
+
+  def self.default_boolean_rule_klass=(val)
+    @default_boolean_rule_klass = val 
+  end
+
   def self.features(&features)
     if !features.nil?
       @feature_registry = FeatureRegistry.create(&features)

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -10,14 +10,14 @@ module Togls
 
     def on(rule = nil)
       if rule.nil?
-        rule = Togls::Rules::Boolean.new(true)
+        rule = Togls.default_boolean_rule_klass.new(true)
       end
       @rule = rule 
       self
     end
 
     def off
-      @rule = Togls::Rules::Boolean.new(false)
+      @rule = Togls.default_boolean_rule_klass.new(false)
       self
     end
 
@@ -26,7 +26,7 @@ module Togls
     end
 
     def to_s
-      if @rule.is_a?(Togls::Rules::Boolean)
+      if @rule.is_a?(Togls.default_boolean_rule_klass)
         display_value = @rule.run ? ' on' : 'off'
       else
         display_value = '  ?'

--- a/spec/lib/togls_spec.rb
+++ b/spec/lib/togls_spec.rb
@@ -1,6 +1,42 @@
 require_relative '../spec_helper'
 
 describe Togls do
+  describe ".default_boolean_rule_klass" do
+    context "when it has NOT been set" do
+      it "returns the class of the default boolean rule" do
+        expect(subject.default_boolean_rule_klass).to eq(Togls::Rules::Boolean)
+      end
+    end
+
+    context "when it HAS been set" do
+      before do
+        @default_boolean_rule_klass = double('default rule klass')
+        subject.instance_variable_set(:@default_boolean_rule_klass,
+                                      @default_boolean_rule_klass) 
+      end
+
+      after do
+        subject.send(:remove_instance_variable, :@default_boolean_rule_klass)
+      end
+
+      it "returns the class the default boolean rule was set to" do
+        expect(subject.default_boolean_rule_klass).to eq(@default_boolean_rule_klass)
+      end
+    end
+  end
+
+  describe ".default_boolean_rule_klass=" do
+    after do
+      subject.send(:remove_instance_variable, :@default_boolean_rule_klass)
+    end
+
+    it "assigns the default boolean rule klass to an instance variable"  do
+      some_rule_klass = double('some rule klass')
+      subject.default_boolean_rule_klass = some_rule_klass
+      expect(subject.instance_variable_get(:@default_boolean_rule_klass)).to eq(some_rule_klass)
+    end
+  end
+
   describe ".features" do
     context "when features have NOT been defined" do
       context "when given a block" do


### PR DESCRIPTION
I did this in preparation for adding environment variable based override
boolean rules. This way, we can simply change the default boolean rule that is
used depending on the app it is used in. Some teams may want the
BooleanEnvOverride rules that are coming in the future, while others may still
just want the normal Boolean rule to be default.