### PR TITLE
Add boolean env override rule

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@ versions, as well as provide a rough history.
 
 * Rename var in `FeatureRegistry.create` avoid confusion with overloaded name
 * Make default boolean rule class configurable
+* Add `Togls::Rules::BooleanEnvOverride` to allow environment based overrides
+* Add Provided Rules Reference to README.md
 
 #### v1.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ versions, as well as provide a rough history.
 * Make default boolean rule class configurable
 * Add `Togls::Rules::BooleanEnvOverride` to allow environment based overrides
 * Add Provided Rules Reference to README.md
+* Rule interface now requires feature key be first arg of run()
 
 #### v1.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ versions, as well as provide a rough history.
 #### Next Release
 
 * Rename var in `FeatureRegistry.create` avoid confusion with overloaded name
+* Make default boolean rule class configurable
 
 #### v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ off - :test3 - test 3 feature
 Below is a breakdown of some of the more advanced features of `Togls` which
 aren't necessary in order to use it for basic feature toggles.
 
+### Override Default Boolean Rule
+
+`Togls` allows you to override the Rule class that is used for default boolean
+values. The default boolean rule class is `Togls::Rules::Boolean`.
+
+If you want to use a different default boolean rule you can override the
+default using the following:
+
+```ruby
+Togls.default_boolean_rule_klass = WhateverBooleanRuleKlassYouWant
+```
+
 ### Custom Rules
 
 `Togls` is specifically architected on top of a generic concept of a

--- a/README.md
+++ b/README.md
@@ -288,20 +288,14 @@ explanations, and some examples of how they can be used.
 
 ### Togls::Rules::Boolean
 
-This is the simplest of the provided rules. In fact it is also the
-**default** rule that is used with the
-`Togls.default_boolean_rule_klass`. It simply takes a boolean during
-construction and returns that boolean value when `run` is called on it.
-Example:
+This is the simplest of the provided rules. It simply takes a boolean
+during construction and returns that boolean value when `run` is called
+on it. Example:
 
 ```ruby
 rule = Togls::Rules::Boolean.new(true)
 rule.run(:some_feature_key) # => true
 ```
-
-For a real world example of how Togls itself uses the this rule as
-the `default_boolean_rule_klass`. Check out 
-[togls/lib/togls/feature.rb](https://github.com/codebreakdown/togls/blob/master/lib/togls/feature.rb).
 
 ### Togls::Rules::BooleanEnvOverride
 
@@ -329,19 +323,6 @@ environment variables set in various environments to override your in
 code values of feature toggles. A prime example of this is often
 Development, QA, Product, Design, because they want to test a feature
 or a portion of a feature that is toggled off in code.
-
-*Note:* This rule conforms to the interface of the
-`default_boolean_rule_klass`. Therefore, it can be set as the default
-boolean rule class by doing the following.
-
-```ruby
-Togls.default_boolean_rule_klass = Togls::Rules::BooleanEnvOverride
-
-Togls.features do
-  feature(:pop_up_login_form, "use the pop up login instead of normal login").on 
-  feature(:send_follup_email, "send the follow up email").off
-end
-```
 
 The above would allow any of your features defined by using the simple
 `on` or `off` methods to be overridden by an environment variable

--- a/README.md
+++ b/README.md
@@ -165,14 +165,19 @@ which aren't necessary in order to use it for basic feature toggles.
 ### Override Default Boolean Rule
 
 `Togls` allows you to override the Rule class that is used for default
-boolean values. The default boolean rule class is
+boolean values. This rule class is used when you use the convenience
+methods `on` and `off`. The default boolean rule class is
 `Togls::Rules::Boolean`.
 
-If you want to use a different default boolean rule you can override the
-default using the following:
+If you want to use a different default boolean rule, lets say,
+`Togls::Rules::BooleanEnvOverride`  you can override the default by
+doing the following:
 
 ```ruby
-Togls.default_boolean_rule_klass = WhateverBooleanRuleKlassYouWant
+Togls.features(Togls::Rules::BooleanEnvOverride) do
+  feature(:some_feature, "some feature description").on
+  feature(:some_other_feature, "some other feature description").on
+end
 ```
 
 ### Custom Rules
@@ -196,7 +201,7 @@ be used to evaluate the boolean result as well.
 gmail_rule = Togls::Rule.new { |key, target| target =~ /gmail.com$/ }
 
 Togls.features do
-  feature(:only_gmail_users).on(gmail_rule)
+  feature(:only_gmail_users, "Only enabled for Gmail users").on(gmail_rule)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Coverage](https://img.shields.io/codeclimate/coverage/github/codebreakdown/togls
 
 # Togls
 
-A lightweight feature toggle library.
+A lightweight feature toggle library for Ruby.
 
 ## Installation
 
@@ -31,18 +31,21 @@ The basic usage of `Togls` is outlined below.
 
 ### Defining Feature Toggles
 
-The first thing to do to use `Togls` is to define your feature toggles. The
-following is an example of how you might define your feature toggles. It is
-recommended this live in its own file. In Rails projects we recommend putting
-it in `config/initializers/togls_features.rb`.
+The first thing to do to use `Togls` is to define your feature toggles.
+The following is an example of how you might define your feature
+toggles. It is recommended this live in its own file. In Rails projects
+we recommend putting it in `config/initializers/togls_features.rb`.
 
 ```ruby
 Togls.features do
   # Set this feature to always be on
   feature(:pop_up_login_form, "use the pop up login instead of normal login").on 
+
   # Set this feature to always be off
   feature(:send_follup_email, "send the follow up email").off
-  # Create a group rule
+
+  # Create a group rule so the feature is on if the user is a member of
+  # the group.
   rule = Togls::Rules::Group.new(["user@email.com"])
   feature(:new_contact_form, "use new contact form instead of old one").on(rule)
 end
@@ -50,9 +53,9 @@ end
 
 ### Evaluating Feature Toggles
 
-Once you have defined your feature toggles. The next thing you would likely
-want to do is conditionally control something based on them. The following are
-a few examples of how you would do this given the above.
+Once you have defined your feature toggles. The next thing you would
+likely want to do is conditionally control something based on them. The
+following are a few examples of how you would do this given the above.
 
 ```ruby
 if Togls.feature(:pop_up_login_form).on?
@@ -72,22 +75,24 @@ else
 end
 ```
 
-**Note:** The default behaviour for any feature that has not been defined that
-is accessed is to default to false.
+**Note:** The default behaviour for any feature that has not been
+defined and is accessed is to default to **off**.
 
 ### Output Feature Toggles
 
-One other use case that we support as part of the *Basic Usage* is outputing all
-of the features in your system and their respective, **states** (`on`, `off`, `?` -
-unkown due to *Complex Rule*), **key**, and **human readable descrption**.
+One other use case that we support as part of the *Basic Usage* is
+outputing all of the features in your system and their respective,
+**states** (`on`, `off`, `?` - unkown due to *Complex Rule*), **key**,
+and **human readable descrption**.
 
-We provide this functionality via a [rake](https://github.com/ruby/rake) task.
+We provide this functionality via a [rake](https://github.com/ruby/rake)
+task.
 
 #### Load rake task
 
 To use it you must first load the provided
-[rake](https://github.com/ruby/rake) file. This can be done in a number of
-different ways.
+[rake](https://github.com/ruby/rake) file. This can be done in a number
+of different ways.
 
 ##### Load rake task in another gem
 
@@ -99,13 +104,14 @@ spec = Gem::Specification.find_by_name 'togls'
 load "#{spec.gem_dir}/lib/tasks/togls.rake"
 ```
 
-**Note:** The features must be defined and loaded before calling this task or
-it will error out informing you that you need to define your features first.
+**Note:** The features must be defined and loaded before calling this
+task or it will error out informing you that you need to define your
+features first.
 
 ##### Load rake task in a Rails app
 
-To use the it in a Rails app you can do so by adding the following to the
-`Rakefile`.
+To use the it in a Rails app you can do so by adding the following to
+the `Rakefile`.
 
 ```ruby
 namespace :togls do
@@ -117,17 +123,17 @@ spec = Gem::Specification.find_by_name 'togls'
 load "#{spec.gem_dir}/lib/tasks/togls.rake"
 ```
 
-**Note:** The first hunk where it defines an empty `togls:features` tasks is
-important in Rails because it takes advantage of
-[rake](https://github.com/ruby/rake) task stacking and calls out the Rails
-environment as a dependency. That way before the `togls:feature` task is
-executed the `config/initializers/togls_features.rb` file is loaded which
-defines the feature toggles.
+**Note:** The first hunk where it defines an empty `togls:features`
+tasks is important in Rails because it takes advantage of
+[rake](https://github.com/ruby/rake) task stacking and calls out the
+Rails environment as a dependency. That way before the `togls:feature`
+task is executed the `config/initializers/togls_features.rb` file is
+loaded which defines the feature toggles.
 
 #### Verify rake task loaded
 
-To verify that the rake task is loaded you can run `rake -T` and you should
-see something similar to the following in the output.
+To verify that the rake task is loaded you can run `rake -T` and you
+should see something similar to the following in the output.
 
 ```text
 rake togls:features                     # Output all features including status (on, off, ? - unknown due to complex rule), ke...
@@ -135,15 +141,15 @@ rake togls:features                     # Output all features including status (
 
 #### Run the rake task
 
-Once you have verified the task is loaded and available you can run it as
-follows.
+Once you have verified the task is loaded and available you can run it
+as follows.
 
 ```shell
 rake togls:features
 ```
 
-The following is an example of what the output might look like if you defined
-a few test features.
+The following is an example of what the output might look like if you
+defined a few test features.
 
 ```text
  on - :test1 - test 1 feature
@@ -153,13 +159,14 @@ off - :test3 - test 3 feature
 
 ## Advanced Usage
 
-Below is a breakdown of some of the more advanced features of `Togls` which
-aren't necessary in order to use it for basic feature toggles.
+Below is a breakdown of some of the more advanced features of `Togls`
+which aren't necessary in order to use it for basic feature toggles.
 
 ### Override Default Boolean Rule
 
-`Togls` allows you to override the Rule class that is used for default boolean
-values. The default boolean rule class is `Togls::Rules::Boolean`.
+`Togls` allows you to override the Rule class that is used for default
+boolean values. The default boolean rule class is
+`Togls::Rules::Boolean`.
 
 If you want to use a different default boolean rule you can override the
 default using the following:
@@ -171,20 +178,22 @@ Togls.default_boolean_rule_klass = WhateverBooleanRuleKlassYouWant
 ### Custom Rules
 
 `Togls` is specifically architected on top of a generic concept of a
-`Togls::Rule`.  This empowers the users to define any custom rules they would
-like and use them to control their feature toggles.  For example, you could
-use them to do A/B testing, define alpha test group, give a percentage of a
-user base a feature, etc.
+`Togls::Rule`.  This empowers the users to define any custom rules they
+would like and use them to control their feature toggles.  For example,
+you could use them to do A/B testing, define alpha test group, give a
+percentage of a user base a feature, etc.
 
 ### Simple Rules
 
-A simple rule can be defined by creating a rule object and passing a block. In
-the following example any feature using the `gmail_rule` would only be on if
-the given `target` contained `gmail.com` at the end of the `target`.
+A simple rule can be defined by creating a rule object and passing a
+block. In the following example any feature using the `gmail_rule` would
+only be on if the given `target` contained `gmail.com` at the end of the
+`target`. *Note:* The block is also handed the feature's key which can
+be used to evaluate the boolean result as well.
 
 ```ruby
 # Only allow users with email addresses at gmail.com
-gmail_rule = Togls::Rule.new { |target| target =~ /gmail.com$/ }
+gmail_rule = Togls::Rule.new { |key, target| target =~ /gmail.com$/ }
 
 Togls.features do
   feature(:only_gmail_users).on(gmail_rule)
@@ -193,35 +202,38 @@ end
 
 ### Complex Rules
 
-To implement a more complex rule, a new rule object can be defined under
-`Togls::Rules` that abides by the following.
+To implement a more complex rule, a new rule object can be defined that
+abides by the following.
 
 - inherits from `Togls::Rule` or a decendent of it
-- has an instance method named `run` that takes either a default value
-  parameter of `target` or a required paramter of `target`.
+- has an instance method named `run` that takes a required feature key
+  and either a default value parameter of `target` or a required
+  paramter of `target`.
 
     ```ruby
-    def run(target = 'foo')
+    def run(key, target = 'foo')
     ...
     end
     
     # or
 
-    def run(target)
+    def run(key, target)
     ...
     end
     ```
 
-- has the instance method named `run` return a boolean value identifying if
-  that feature should be on(`true`)/off(`false`) given the `target`.
+- has the instance method named `run` return a boolean value identifying
+  if that feature should be on(**true**)/off(**false**) given the `key`
+  and `target`.
 
 Thats it!
 
 #### Example Complex Rule
 
-Internally `Togls` uses these *Complex Rules* to provide functionality and
-will evolve to contain more official rules over time. If you have a generic
-*Complex Rule* you think should be part of `Togls` please make a pull request.
+Internally `Togls` uses these *Complex Rules* to provide functionality
+and will evolve to contain more official rules over time. If you have a
+generic *Complex Rule* you think should be part of `Togls` please make a
+pull request.
 
 A prime example of a *Complex Rule* provided by `Togls` is the
 `Togls::Rules::Group` rule. You can see it below.
@@ -234,7 +246,7 @@ module Togls
         @list = list
       end
 
-      def run(target)
+      def run(key, target)
         @list.include?(target)
       end
     end
@@ -244,54 +256,54 @@ end
 
 Lets take a closer look at exactly what is going on here.
 
-- it is inheriting from the `Togls::Rule` class which meets one of the minimum
-  requirements for a rule.
-- its defines constructor takes an array identifiers and stores them. These
-  identifiers could be id numbers, email address, etc. **Note:** This
-  constructor is completely different than that of `Togls::Rule`. This
-  is fine because it is **not** a requirements that the constructor match.
-- its `run` method returns a boolean value identifying if the feature should
-  be on(`true`)/off(`false`) for the given `target`. It does so by identifying
-  if the array passed in at construction time `include?` the given `target`.
-  This meets one of the minimum requirement for a rule.
-- its `run` method signature requires a `target`. This meets a minimum
-  requirement for a rule as well. It also makes sense in the case of group
-  based rule as it has to have something to compare against the group.
+- it is inheriting from the `Togls::Rule` class which meets one of the
+  minimum requirements for a rule.
+- it defined constructor takes an array of identifiers and stores them.
+  These identifiers could be id numbers, email address, etc. **Note:**
+  This constructor is completely different than that of `Togls::Rule`.
+  This is fine because it is **not** a requirement that the constructor
+  match.
+- its `run` method returns a boolean value identifying if the feature
+  should be on(**true**)/off(**false**) for the given `key` and
+  `target`. It does so by identifying if the array passed in at
+  construction time `include?` the given `target`.  This meets one of
+  the minimum requirement for a rule.
+- its `run` method signature requires a `key` and `target`. This meets a
+  minimum requirement for a rule as well. It also makes sense in the
+  case of group based rule as it has to have something to compare
+  against the group.
 
-*Complex Rules* are a simple yet extremely power concept that you shouldn't
-hesitate to use.
+*Complex Rules* are a simple yet extremely power concept that you
+shouldn't hesitate to use.
 
 ## Provided Rules Reference
 
-The following is a list of all of the provided rules, their explanations, and
-some examples of how they can be used.
+The following is a list of all of the provided rules, their
+explanations, and some examples of how they can be used.
 
 ### Togls::Rules::Boolean
 
-This is the simplest of the provided rules. In fact it is also the **default**
-rule that is used with the `Togls.default_boolean_rule_klass`. It simply takes
-a boolean during construction and returns that boolean value when `run` is
-called on it. Example:
+This is the simplest of the provided rules. In fact it is also the
+**default** rule that is used with the
+`Togls.default_boolean_rule_klass`. It simply takes a boolean during
+construction and returns that boolean value when `run` is called on it.
+Example:
 
 ```ruby
 rule = Togls::Rules::Boolean.new(true)
-rule.run # => true
+rule.run(:some_feature_key) # => true
 ```
 
-*Note:* The constructor can optionally take the `feature_key` in addition to
-the boolean value, but it is ignored.
-
 For a real world example of how Togls itself uses the this rule as
-the `default_boolean_rule_klass`. Check out the following.
-
-[togls/lib/togls/feature.rb](https://github.com/codebreakdown/togls/blob/master/lib/togls/feature.rb)
+the `default_boolean_rule_klass`. Check out 
+[togls/lib/togls/feature.rb](https://github.com/codebreakdown/togls/blob/master/lib/togls/feature.rb).
 
 ### Togls::Rules::BooleanEnvOverride
 
-This rule is nearly the same as the `Togls::Rules::Boolean` rule with one very
-important difference. It allows the initialized values of the rules to be
-overriden at runtime via environment variables following the naming scheme
-below.
+This rule is nearly the same as the `Togls::Rules::Boolean` rule with
+one very important difference. It allows the initialized values of the
+rules to be overriden at runtime via environment variables following the
+naming scheme below.
 
 ```shell
 TOGLS_<feature_key as a string upper cased>
@@ -301,20 +313,21 @@ TOGLS_<feature_key as a string upper cased>
 whatever the `feature_key` is as a string when upper cased.
 
 For example. Lets say you have a feature key of
-`:new_forecasting_algorithm`. The value of this rule could be set to **true**
-by setting the environment variable, `TOGLS_NEW_FORECASTING_ALGORITHM` to
-a value of `"true"`. If `TOGLS_NEW_FORECASTING_ALGORITHM` is any value
-other than `"true"` the rule will return **false**.
+`:new_forecasting_algorithm`. The value of this rule could be set to
+**true** by setting the environment variable,
+`TOGLS_NEW_FORECASTING_ALGORITHM` to a value of `"true"`. If
+`TOGLS_NEW_FORECASTING_ALGORITHM` is any value other than `"true"` the
+rule will return **false**.
 
 This type of rule is extremely useful when you want to be able to use
-environment variables set in various environments to override your in code
-values of feature toggles. A prime example of this is often QA, Product,
-Design, because they wants to test a feature or a portion of a feature that is
-toggled off in code.
+environment variables set in various environments to override your in
+code values of feature toggles. A prime example of this is often
+Development, QA, Product, Design, because they want to test a feature
+or a portion of a feature that is toggled off in code.
 
 *Note:* This rule conforms to the interface of the
-`default_boolean_rule_klass`. Therefore, it can be set as the default boolean
-rule class by doing the following.
+`default_boolean_rule_klass`. Therefore, it can be set as the default
+boolean rule class by doing the following.
 
 ```ruby
 Togls.default_boolean_rule_klass = Togls::Rules::BooleanEnvOverride
@@ -325,15 +338,19 @@ Togls.features do
 end
 ```
 
+The above would allow any of your features defined by using the simple
+`on` or `off` methods to be overridden by an environment variable
+following the schema described above.
+
 ### Togls::Rules::Group
 
-This rule is intended to allow feature toggles to be able to controled based
-on someone or something existing/not exsiting within a group. For example this
-could be used to enable a feature on for a specified list of email addresses.
+This rule is intended to allow feature toggles to be able to be
+controled based on someone or something existing/not exsiting within a
+group. For example this could be used to enable a feature for a
+specified list of email addresses.
 
 ```ruby
 # defining the feature toggles
-
 Togls.features do
   # Create a group rule
   rule = Togls::Rules::Group.new(["drew@example.com", "brian@example.com"])
@@ -341,7 +358,6 @@ Togls.features do
 end
 
 # evaluating the feature toggles
-
 if Togls.feature(:new_contact_form).on?("user@example.com")
   # Use new contact form
 else
@@ -352,8 +368,9 @@ end
 In the above snippet the `:new_contact_form` feature toggle is on/off
 conditionally based on if "user@example.com" is in the group
 ("drew@example.com", "brian@example.com"). In this particular case
-"user@example.com" is not. Therefore, `on?` would come back with a value of
-**false** and we would end up in the `# Use old contact form` branch.
+"user@example.com" is not. Therefore, `on?` would come back with a value
+of **false** and we would end up in the `# Use old contact form` code
+branch.
 
 ## Development
 

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -7,6 +7,18 @@ require "togls/rules"
 require "logger"
 
 module Togls
+  def self.default_boolean_rule_klass
+    if @default_boolean_rule_klass
+      return @default_boolean_rule_klass
+    else
+      return Togls::Rules::Boolean
+    end
+  end
+
+  def self.default_boolean_rule_klass=(val)
+    @default_boolean_rule_klass = val 
+  end
+
   def self.features(&features)
     if !features.nil?
       @feature_registry = FeatureRegistry.create(&features)

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -7,21 +7,9 @@ require "togls/rules"
 require "logger"
 
 module Togls
-  def self.default_boolean_rule_klass
-    if @default_boolean_rule_klass
-      return @default_boolean_rule_klass
-    else
-      return Togls::Rules::Boolean
-    end
-  end
-
-  def self.default_boolean_rule_klass=(val)
-    @default_boolean_rule_klass = val 
-  end
-
-  def self.features(&features)
+  def self.features(base_type_klass = Togls::Rules::Boolean, &features)
     if !features.nil?
-      @feature_registry = FeatureRegistry.create(&features)
+      @feature_registry = FeatureRegistry.create(base_type_klass, &features)
     else
       if @feature_registry.nil?
         raise Togls::NoFeaturesError, "Need to define features before you can get them"

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -10,14 +10,14 @@ module Togls
 
     def on(rule = nil)
       if rule.nil?
-        rule = Togls.default_boolean_rule_klass.new(true)
+        rule = Togls.default_boolean_rule_klass.new(true, @key)
       end
       @rule = rule 
       self
     end
 
     def off
-      @rule = Togls.default_boolean_rule_klass.new(false)
+      @rule = Togls.default_boolean_rule_klass.new(false, @key)
       self
     end
 

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -10,24 +10,24 @@ module Togls
 
     def on(rule = nil)
       if rule.nil?
-        rule = Togls.default_boolean_rule_klass.new(true, @key)
+        rule = Togls.default_boolean_rule_klass.new(true)
       end
       @rule = rule 
       self
     end
 
     def off
-      @rule = Togls.default_boolean_rule_klass.new(false, @key)
+      @rule = Togls.default_boolean_rule_klass.new(false)
       self
     end
 
     def on?(target = nil)
-      @rule.run(target)
+      @rule.run(@key, target)
     end
 
     def to_s
       if @rule.is_a?(Togls.default_boolean_rule_klass)
-        display_value = @rule.run ? ' on' : 'off'
+        display_value = @rule.run(@key) ? ' on' : 'off'
       else
         display_value = '  ?'
       end

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -10,14 +10,14 @@ module Togls
 
     def on(rule = nil)
       if rule.nil?
-        rule = Togls::Rules::Boolean.new(true)
+        rule = Togls.default_boolean_rule_klass.new(true)
       end
       @rule = rule 
       self
     end
 
     def off
-      @rule = Togls::Rules::Boolean.new(false)
+      @rule = Togls.default_boolean_rule_klass.new(false)
       self
     end
 
@@ -26,7 +26,7 @@ module Togls
     end
 
     def to_s
-      if @rule.is_a?(Togls::Rules::Boolean)
+      if @rule.is_a?(Togls.default_boolean_rule_klass)
         display_value = @rule.run ? ' on' : 'off'
       else
         display_value = '  ?'

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -2,22 +2,23 @@ module Togls
   class Feature
     attr_reader :key, :description
 
-    def initialize(key, description)
+    def initialize(key, description, base_rule_klass)
       @key = key
       @description = description
+      @base_rule_klass = base_rule_klass
       off
     end
 
     def on(rule = nil)
       if rule.nil?
-        rule = Togls.default_boolean_rule_klass.new(true)
+        rule = @base_rule_klass.new(true)
       end
       @rule = rule 
       self
     end
 
     def off
-      @rule = Togls.default_boolean_rule_klass.new(false)
+      @rule = @base_rule_klass.new(false)
       self
     end
 
@@ -26,7 +27,7 @@ module Togls
     end
 
     def to_s
-      if @rule.is_a?(Togls.default_boolean_rule_klass)
+      if @rule.is_a?(@base_rule_klass)
         display_value = @rule.run(@key) ? ' on' : 'off'
       else
         display_value = '  ?'

--- a/lib/togls/feature_registry.rb
+++ b/lib/togls/feature_registry.rb
@@ -1,18 +1,22 @@
 module Togls
   class FeatureRegistry
-    def initialize
+    def initialize(base_rule_klass)
+      @base_rule_klass = base_rule_klass
       @registry = {}
-      @default_feature = Feature.new(:default, "the official default feature").on(Rule.new { false })
+      @default_feature = Feature.new(:default,
+                                     "the official default feature",
+                                     @base_rule_klass).on(Rule.new { false })
     end
 
-    def self.create(&features)
-      feature_registry = self.new
+    def self.create(base_rule_klass, &features)
+      feature_registry = self.new(base_rule_klass)
       feature_registry.instance_eval(&features) 
       feature_registry
     end
 
     def feature(tag, desc)
-      @registry[tag.to_sym] = Feature.new(tag.to_sym, desc)
+      @registry[tag.to_sym] = Feature.new(tag.to_sym, desc,
+                                          @base_rule_klass)
     end
 
     def get(key)

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -4,8 +4,8 @@ module Togls
       @definition = rule  
     end
 
-    def run(target = nil)
-      @definition.call(target)
+    def run(key, target = nil)
+      @definition.call(key, target)
     end
   end
 end

--- a/lib/togls/rules.rb
+++ b/lib/togls/rules.rb
@@ -1,4 +1,5 @@
 require 'togls/rules/boolean'
+require 'togls/rules/boolean_env_override'
 require 'togls/rules/group'
 
 module Togls

--- a/lib/togls/rules/boolean.rb
+++ b/lib/togls/rules/boolean.rb
@@ -1,12 +1,11 @@
 module Togls
   module Rules
     class Boolean < Rule
-      def initialize(bool, feature_key = nil)
+      def initialize(bool)
         @bool = bool
-        @feature_key = feature_key
       end
 
-      def run(target = nil)
+      def run(key, target = nil)
         return @bool
       end
     end

--- a/lib/togls/rules/boolean.rb
+++ b/lib/togls/rules/boolean.rb
@@ -1,8 +1,9 @@
 module Togls
   module Rules
     class Boolean < Rule
-      def initialize(bool)
+      def initialize(bool, feature_key = nil)
         @bool = bool
+        @feature_key = feature_key
       end
 
       def run(target = nil)

--- a/lib/togls/rules/boolean_env_override.rb
+++ b/lib/togls/rules/boolean_env_override.rb
@@ -3,9 +3,9 @@ require_relative 'boolean'
 module Togls
   module Rules
     class BooleanEnvOverride < Boolean
-      def run(target = nil)
-        if ENV[feature_env_key]
-          if ENV[feature_env_key] == "true"
+      def run(key, target = nil)
+        if ENV[feature_env_key(key)]
+          if ENV[feature_env_key(key)] == "true"
             return true
           else
             return false
@@ -17,8 +17,8 @@ module Togls
 
       private
 
-      def feature_env_key
-        return "TOGLS_#{@feature_key.to_s.upcase}"
+      def feature_env_key(feature_key)
+        return "TOGLS_#{feature_key.to_s.upcase}"
       end
     end
   end

--- a/lib/togls/rules/boolean_env_override.rb
+++ b/lib/togls/rules/boolean_env_override.rb
@@ -1,0 +1,25 @@
+require_relative 'boolean'
+
+module Togls
+  module Rules
+    class BooleanEnvOverride < Boolean
+      def run(target = nil)
+        if ENV[feature_env_key]
+          if ENV[feature_env_key] == "true"
+            return true
+          else
+            return false
+          end
+        else
+          return @bool
+        end
+      end
+
+      private
+
+      def feature_env_key
+        return "TOGLS_#{@feature_key.to_s.upcase}"
+      end
+    end
+  end
+end

--- a/lib/togls/rules/group.rb
+++ b/lib/togls/rules/group.rb
@@ -5,7 +5,7 @@ module Togls
         @list = list
       end
 
-      def run(target)
+      def run(key, target)
         @list.include?(target)
       end
     end

--- a/spec/features/togls_spec.rb
+++ b/spec/features/togls_spec.rb
@@ -45,6 +45,23 @@ describe "Togl feature creation" do
     expect(Togls.feature(:test).on?("someone_else")).to eq(false)
   end
 
+
+  context "environment variable feature override" do
+    after do
+      ENV.delete("TOGLS_TEST")
+    end
+
+    it "creates a new feature with a boolean env override rule as the base_rule_klass" do
+      Togls.features(Togls::Rules::BooleanEnvOverride) do
+        feature(:test, "some human readable description").on
+      end
+
+      ENV["TOGLS_TEST"] = "aeuaoeuaeouaoeuue"
+
+      expect(Togls.feature(:test).on?).to eq(false)
+    end
+  end
+
   it "outputs all the features" do
     Togls.features do
       feature(:test1, "test1 readable description").on

--- a/spec/lib/togls/feature_registry_spec.rb
+++ b/spec/lib/togls/feature_registry_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../../spec_helper'
 
 describe Togls::FeatureRegistry do
+  subject { Togls::FeatureRegistry.new(Togls::Rules::Boolean) }
   let(:key) { :key }
 
   describe "#initalize" do
@@ -20,7 +21,7 @@ describe Togls::FeatureRegistry do
       registry = double('registry')
       expect(Togls::FeatureRegistry).to receive(:new).and_return(registry)
       b = Proc.new {}
-      Togls::FeatureRegistry.create(&b)
+      Togls::FeatureRegistry.create(double, &b)
     end
 
     it "calls instance eval with the passed block" do
@@ -28,31 +29,34 @@ describe Togls::FeatureRegistry do
       allow(Togls::FeatureRegistry).to receive(:new).and_return(feature_registry)
       b = Proc.new {}
       expect(feature_registry).to receive(:instance_eval).and_yield(&b)
-      Togls::FeatureRegistry.create(&b)
+      Togls::FeatureRegistry.create(double, &b)
     end
 
     it "returns a configured feature registry object" do
       b = Proc.new {}
-      expect(Togls::FeatureRegistry.create(&b)).to be_a(Togls::FeatureRegistry)
+      expect(Togls::FeatureRegistry.create(Togls::Rules::Boolean, &b)).to be_a(Togls::FeatureRegistry)
     end
   end
 
 
   describe "#feature" do
     before do
-      allow(Togls::Feature).to receive(:new).with(:default, "the official default feature").and_return(spy)
+      allow(Togls::Feature).to receive(:new).with(:default, "the official default feature",
+                                                  Togls::Rules::Boolean).and_return(spy)
     end
 
     it "creates a new feature object with the passed key" do
       desc = double('feature desc')
-      expect(Togls::Feature).to receive(:new).with(key, desc)
+      expect(Togls::Feature).to receive(:new).with(key, desc,
+                                                   Togls::Rules::Boolean)
       subject.feature(key, desc)
     end
 
     it "adds the feature to the registry" do
       desc = double('feature desc')
       feature = double('feature')
-      allow(Togls::Feature).to receive(:new).with(key, desc).and_return(feature)
+      allow(Togls::Feature).to receive(:new).with(key, desc,
+                                                  Togls::Rules::Boolean).and_return(feature)
       subject.feature(key, desc)
       expect(subject.instance_variable_get(:@registry)[key]).to eq(feature)
     end
@@ -60,14 +64,16 @@ describe Togls::FeatureRegistry do
 
   describe "#get" do
     before do
-      allow(Togls::Feature).to receive(:new).with(:default, "the official default feature").and_return(spy)
+      allow(Togls::Feature).to receive(:new).with(:default, "the official default feature",
+                                                  Togls::Rules::Boolean).and_return(spy)
     end
 
     context "when feature exists in registry" do
       it "returns the feature identified by key" do
         desc = double('feature desc')
         feature = double('feature')
-        allow(Togls::Feature).to receive(:new).with(key, desc).and_return(feature)
+        allow(Togls::Feature).to receive(:new).with(key, desc,
+                                                    Togls::Rules::Boolean).and_return(feature)
         subject.feature(key, desc)
         expect(subject.get(key)).to eq(feature)
       end
@@ -91,7 +97,7 @@ describe Togls::FeatureRegistry do
   describe "#registry" do
     it "returns the registry of feature objects" do
       feature_double = double('feature')
-      feature_registry = Togls::FeatureRegistry.create do
+      feature_registry = Togls::FeatureRegistry.create(Togls::Rules::Boolean) do
       end
       feature_registry.instance_variable_set(:@registry, { :test => feature_double })
       expect(feature_registry.registry).to eq({ :test => feature_double })

--- a/spec/lib/togls/feature_spec.rb
+++ b/spec/lib/togls/feature_spec.rb
@@ -27,7 +27,7 @@ describe Togls::Feature do
 
     it "sets the feature rule to true" do
       subject.on
-      expect(subject.instance_variable_get(:@rule).run).to eq(true)
+      expect(subject.instance_variable_get(:@rule).run(double('feature key'))).to eq(true)
     end
 
     it "returns its associated feature object" do
@@ -46,7 +46,8 @@ describe Togls::Feature do
 
     it "sets the feature rule to false" do
       subject.off
-      expect(subject.instance_variable_get(:@rule).run).to eq(false)
+      expect(subject.instance_variable_get(:@rule).\
+             run(double('feature key'))).to eq(false)
     end
 
     it "returns its associated feature object" do
@@ -60,7 +61,7 @@ describe Togls::Feature do
       rule = double('rule')
       target = double('target')
       subject.instance_variable_set(:@rule, rule)
-      expect(rule).to receive(:run).with(target)
+      expect(rule).to receive(:run).with(subject.key, target)
       subject.on?(target)
     end
 

--- a/spec/lib/togls/feature_spec.rb
+++ b/spec/lib/togls/feature_spec.rb
@@ -1,7 +1,8 @@
 require_relative '../../spec_helper'
 
 describe Togls::Feature do
-  subject { Togls::Feature.new(:key, "some description") }
+  subject { Togls::Feature.new(:key, "some description",
+                               Togls::Rules::Boolean) }
 
   describe "#initialize" do
     it "assigns the passed key" do
@@ -82,7 +83,8 @@ describe Togls::Feature do
   describe "#to_s" do
     context "when based on boolean rule" do
       it "returns a human readable string representation of the feature including value" do
-        feature = Togls::Feature.new(:key, "some description").on(Togls::Rules::Boolean.new(true))
+        feature = Togls::Feature.new(:key, "some description",
+                                     Togls::Rules::Boolean).on(Togls::Rules::Boolean.new(true))
         expect(feature.to_s).to eq(" on - :key - some description")
       end
     end
@@ -90,7 +92,7 @@ describe Togls::Feature do
     context "when NOT based on boolean rule" do
       it "returns a human readable string representation of the feature with an unknown value" do
         rule = Togls::Rule.new { |v| !v }
-        feature = Togls::Feature.new(:another_key, "another description").on(rule)
+        feature = Togls::Feature.new(:another_key, "another description", Togls::Rules::Boolean).on(rule)
         expect(feature.to_s).to eq("  ? - :another_key - another description")
       end
     end

--- a/spec/lib/togls/rule_spec.rb
+++ b/spec/lib/togls/rule_spec.rb
@@ -12,7 +12,7 @@ describe Togls::Rule do
   describe "#run" do
     it "runs the defined rule" do
       rule = Togls::Rule.new { "test value" }
-      expect(rule.run).to eq("test value")
+      expect(rule.run(double('feature key'))).to eq("test value")
     end
   end
 end

--- a/spec/lib/togls/rules/boolean_env_override_spec.rb
+++ b/spec/lib/togls/rules/boolean_env_override_spec.rb
@@ -1,0 +1,54 @@
+require_relative '../../../spec_helper'
+
+describe Togls::Rules::BooleanEnvOverride do
+  describe "#initialize" do
+    it "stores the passed boolean" do
+      bool = double('bool')
+      group = Togls::Rules::BooleanEnvOverride.new(bool, double)
+      expect(group.instance_variable_get(:@bool)).to eq(bool)
+    end
+
+    it "stores the passed feature key" do
+      feature_key = double('feature key')
+      group = Togls::Rules::BooleanEnvOverride.new(double, feature_key)
+      expect(group.instance_variable_get(:@feature_key)).to eq(feature_key)
+    end
+  end
+
+  describe "#run" do
+    context "when environment variable is NOT present" do
+      it "returns the provided boolean value" do
+        bool_rule = Togls::Rules::BooleanEnvOverride.new(true)
+        expect(bool_rule.run).to eq(true)
+      end
+    end
+
+    context "when environment variable IS present" do
+      context "when environment variable equals 'true'" do
+        after do
+          ENV.delete("TOGLS_TEST_FEATURE_HOOPTY")
+        end
+
+        it "returns true" do
+          ENV["TOGLS_TEST_FEATURE_HOOPTY"]="true"
+          bool_rule = Togls::Rules::BooleanEnvOverride.new(false,
+                                                           :test_feature_hoopty)
+          expect(bool_rule.run).to eq(true)
+        end
+      end
+
+      context "when environment variable does NOT equal 'true'" do
+        after do
+          ENV.delete("TOGLS_TEST_FEATURE_DOOPTY")
+        end
+
+        it "returns false" do
+          ENV["TOGLS_TEST_FEATURE_DOOPTY"]="aeuoeuao"
+          bool_rule = Togls::Rules::BooleanEnvOverride.new(false,
+                                                           :test_feature_hoopty)
+          expect(bool_rule.run).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/togls/rules/boolean_env_override_spec.rb
+++ b/spec/lib/togls/rules/boolean_env_override_spec.rb
@@ -4,14 +4,8 @@ describe Togls::Rules::BooleanEnvOverride do
   describe "#initialize" do
     it "stores the passed boolean" do
       bool = double('bool')
-      group = Togls::Rules::BooleanEnvOverride.new(bool, double)
+      group = Togls::Rules::BooleanEnvOverride.new(bool)
       expect(group.instance_variable_get(:@bool)).to eq(bool)
-    end
-
-    it "stores the passed feature key" do
-      feature_key = double('feature key')
-      group = Togls::Rules::BooleanEnvOverride.new(double, feature_key)
-      expect(group.instance_variable_get(:@feature_key)).to eq(feature_key)
     end
   end
 
@@ -19,7 +13,7 @@ describe Togls::Rules::BooleanEnvOverride do
     context "when environment variable is NOT present" do
       it "returns the provided boolean value" do
         bool_rule = Togls::Rules::BooleanEnvOverride.new(true)
-        expect(bool_rule.run).to eq(true)
+        expect(bool_rule.run(double('feature_key'))).to eq(true)
       end
     end
 
@@ -31,9 +25,8 @@ describe Togls::Rules::BooleanEnvOverride do
 
         it "returns true" do
           ENV["TOGLS_TEST_FEATURE_HOOPTY"]="true"
-          bool_rule = Togls::Rules::BooleanEnvOverride.new(false,
-                                                           :test_feature_hoopty)
-          expect(bool_rule.run).to eq(true)
+          bool_rule = Togls::Rules::BooleanEnvOverride.new(false)
+          expect(bool_rule.run(:test_feature_hoopty)).to eq(true)
         end
       end
 
@@ -44,9 +37,8 @@ describe Togls::Rules::BooleanEnvOverride do
 
         it "returns false" do
           ENV["TOGLS_TEST_FEATURE_DOOPTY"]="aeuoeuao"
-          bool_rule = Togls::Rules::BooleanEnvOverride.new(false,
-                                                           :test_feature_hoopty)
-          expect(bool_rule.run).to eq(false)
+          bool_rule = Togls::Rules::BooleanEnvOverride.new(false)
+          expect(bool_rule.run(:test_feature_doopty)).to eq(false)
         end
       end
     end

--- a/spec/lib/togls/rules/boolean_spec.rb
+++ b/spec/lib/togls/rules/boolean_spec.rb
@@ -4,8 +4,14 @@ describe Togls::Rules::Boolean do
   describe "#initialize" do
     it "stores the passed boolean" do
       bool = double('bool')
-      group = Togls::Rules::Boolean.new(bool)
+      group = Togls::Rules::Boolean.new(bool, double)
       expect(group.instance_variable_get(:@bool)).to eq(bool)
+    end
+
+    it "stores the passed feature key" do
+      feature_key = double('feature key')
+      group = Togls::Rules::Boolean.new(double, feature_key)
+      expect(group.instance_variable_get(:@feature_key)).to eq(feature_key)
     end
   end
 

--- a/spec/lib/togls/rules/boolean_spec.rb
+++ b/spec/lib/togls/rules/boolean_spec.rb
@@ -4,21 +4,15 @@ describe Togls::Rules::Boolean do
   describe "#initialize" do
     it "stores the passed boolean" do
       bool = double('bool')
-      group = Togls::Rules::Boolean.new(bool, double)
+      group = Togls::Rules::Boolean.new(bool)
       expect(group.instance_variable_get(:@bool)).to eq(bool)
-    end
-
-    it "stores the passed feature key" do
-      feature_key = double('feature key')
-      group = Togls::Rules::Boolean.new(double, feature_key)
-      expect(group.instance_variable_get(:@feature_key)).to eq(feature_key)
     end
   end
 
   describe "#run" do
     it "returns the provided boolean value" do
       bool_rule = Togls::Rules::Boolean.new(true)
-      expect(bool_rule.run).to eq(true)
+      expect(bool_rule.run(double)).to eq(true)
     end
   end
 end

--- a/spec/lib/togls/rules/group_spec.rb
+++ b/spec/lib/togls/rules/group_spec.rb
@@ -13,7 +13,7 @@ describe Togls::Rules::Group do
     context "when the target is included in the list" do
       it "returns true" do
         group = Togls::Rules::Group.new(["target"])
-        expect(group.run("target")).to eq(true)
+        expect(group.run(double('feature_key'), "target")).to eq(true)
       end
     end
   end

--- a/spec/lib/togls_spec.rb
+++ b/spec/lib/togls_spec.rb
@@ -1,6 +1,42 @@
 require_relative '../spec_helper'
 
 describe Togls do
+  describe ".default_boolean_rule_klass" do
+    context "when it has NOT been set" do
+      it "returns the class of the default boolean rule" do
+        expect(subject.default_boolean_rule_klass).to eq(Togls::Rules::Boolean)
+      end
+    end
+
+    context "when it HAS been set" do
+      before do
+        @default_boolean_rule_klass = double('default rule klass')
+        subject.instance_variable_set(:@default_boolean_rule_klass,
+                                      @default_boolean_rule_klass) 
+      end
+
+      after do
+        subject.send(:remove_instance_variable, :@default_boolean_rule_klass)
+      end
+
+      it "returns the class the default boolean rule was set to" do
+        expect(subject.default_boolean_rule_klass).to eq(@default_boolean_rule_klass)
+      end
+    end
+  end
+
+  describe ".default_boolean_rule_klass=" do
+    after do
+      subject.send(:remove_instance_variable, :@default_boolean_rule_klass)
+    end
+
+    it "assigns the default boolean rule klass to an instance variable"  do
+      some_rule_klass = double('some rule klass')
+      subject.default_boolean_rule_klass = some_rule_klass
+      expect(subject.instance_variable_get(:@default_boolean_rule_klass)).to eq(some_rule_klass)
+    end
+  end
+
   describe ".features" do
     context "when features have NOT been defined" do
       context "when given a block" do

--- a/spec/lib/togls_spec.rb
+++ b/spec/lib/togls_spec.rb
@@ -1,42 +1,6 @@
 require_relative '../spec_helper'
 
 describe Togls do
-  describe ".default_boolean_rule_klass" do
-    context "when it has NOT been set" do
-      it "returns the class of the default boolean rule" do
-        expect(subject.default_boolean_rule_klass).to eq(Togls::Rules::Boolean)
-      end
-    end
-
-    context "when it HAS been set" do
-      before do
-        @default_boolean_rule_klass = double('default rule klass')
-        subject.instance_variable_set(:@default_boolean_rule_klass,
-                                      @default_boolean_rule_klass) 
-      end
-
-      after do
-        subject.send(:remove_instance_variable, :@default_boolean_rule_klass)
-      end
-
-      it "returns the class the default boolean rule was set to" do
-        expect(subject.default_boolean_rule_klass).to eq(@default_boolean_rule_klass)
-      end
-    end
-  end
-
-  describe ".default_boolean_rule_klass=" do
-    after do
-      subject.send(:remove_instance_variable, :@default_boolean_rule_klass)
-    end
-
-    it "assigns the default boolean rule klass to an instance variable"  do
-      some_rule_klass = double('some rule klass')
-      subject.default_boolean_rule_klass = some_rule_klass
-      expect(subject.instance_variable_get(:@default_boolean_rule_klass)).to eq(some_rule_klass)
-    end
-  end
-
   describe ".features" do
     context "when features have NOT been defined" do
       context "when given a block" do
@@ -85,7 +49,7 @@ describe Togls do
   describe ".feature" do
     it "returns the feature identified by the key" do
       feature = double('feature')
-      feature_registry = Togls::FeatureRegistry.new
+      feature_registry = Togls::FeatureRegistry.new(Togls::Rules::Boolean)
       feature_registry.instance_variable_set(:@registry, {key: feature})
       allow(feature_registry).to receive(:get).with(:key).and_return(feature)
       Togls.instance_variable_set(:@feature_registry, feature_registry)


### PR DESCRIPTION
I did this so that users could override their feature toggles at runtime based
on the environment the application is running in. I also added a Provided
Rules Reference to the README.md to aid people in understand what rules exist
and how they can use them.

*Note:* This includes the changes from pull request https://github.com/codebreakdown/togls/pull/9  as it is a dependency of this pull request. 
