### PR TITLE
Create #on_for method, alias for #on

### DIFF
--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -17,6 +17,8 @@ module Togls
       self
     end
 
+    alias_method :on_for, :on
+
     def off
       @rule = @base_rule_klass.new(false)
       self

--- a/spec/lib/togls/feature_spec.rb
+++ b/spec/lib/togls/feature_spec.rb
@@ -18,22 +18,24 @@ describe Togls::Feature do
     end
   end
 
-  describe "#on" do
-    context "when the rule is nil" do
-      it "creates a new rule" do
-        expect(Togls::Rule).to receive(:new).twice
-        subject.on
+  %w[on on_for].each do |method_name|
+    describe "##{method_name}" do
+      context "when the rule is nil" do
+        it "creates a new rule" do
+          expect(Togls::Rule).to receive(:new).twice
+          subject.on
+        end
       end
-    end
 
-    it "sets the feature rule to true" do
-      subject.on
-      expect(subject.instance_variable_get(:@rule).run(double('feature key'))).to eq(true)
-    end
+      it "sets the feature rule to true" do
+        subject.on
+        expect(subject.instance_variable_get(:@rule).run(double('feature key'))).to eq(true)
+      end
 
-    it "returns its associated feature object" do
-      retval = subject.on
-      expect(retval).to eq(subject)
+      it "returns its associated feature object" do
+        retval = subject.on
+        expect(retval).to eq(subject)
+      end
     end
   end
 


### PR DESCRIPTION
When reading the examples provided I think there is a readable syntax that can
emerge from togls. In times where we are passing `on` message in a feature
block, there can be a better flow when reading togls definitions.

```ruby
#original
Togls.features do
  feature(:new_contact_form, "use new contact form").on(alpha_testers)
end
#alias
Togls.features do
  feature(:new_contact_form, "use new contact form").on_for(alpha_testers)
end
```