### PR TITLE
Add an `off?` conditional method for features

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ versions, as well as provide a rough history.
 * Add `Togls::Rules::BooleanEnvOverride` to allow environment based overrides
 * Add Provided Rules Reference to README.md
 * Rule interface now requires feature key be first arg of run()
+* Add `off?` method for asking if a defined feature is off
 
 #### v1.0.0
 

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -16,6 +16,10 @@ module Togls
       @rule.run(@feature.key, target)
     end
 
+    def off?(target = nil)
+      return !@rule.run(@feature.key, target)
+    end
+
     def to_s
       if @rule.is_a?(Togls::Rules::Boolean)
         display_value = @rule.run(@feature.key) ? ' on' : 'off'

--- a/spec/features/togls_spec.rb
+++ b/spec/features/togls_spec.rb
@@ -45,7 +45,6 @@ describe "Togl feature creation" do
     expect(Togls.feature(:test).on?("someone_else")).to eq(false)
   end
 
-
   context "environment variable feature override" do
     after do
       ENV.delete("TOGLS_TEST")
@@ -61,7 +60,27 @@ describe "Togl feature creation" do
       expect(Togls.feature(:test).on?).to eq(false)
     end
   end
+end
 
+describe "Togl inspection" do
+  it "asks a feature if it is on" do
+    Togls.features do
+      feature(:test, "some human readable description").on
+    end
+
+    expect(Togls.feature(:test).on?).to eq(true)
+  end
+
+  it "asks a feature if it is off" do
+    Togls.features do
+      feature(:test, "some human readable description").on
+    end
+
+    expect(Togls.feature(:test).off?).to eq(false)
+  end
+end
+
+describe "Togl reporting" do
   it "outputs all the features" do
     Togls.features do
       feature(:test1, "test1 readable description").on

--- a/spec/lib/togls/toggle_spec.rb
+++ b/spec/lib/togls/toggle_spec.rb
@@ -68,6 +68,27 @@ describe Togls::Toggle do
     end
   end
 
+  describe "#off?" do
+    it "runs the associated rule" do
+      rule = double('rule')
+      target = double('target')
+      subject.instance_variable_set(:@rule, rule)
+      allow(feature).to receive(:key).and_return("key")
+      expect(rule).to receive(:run).with(subject.feature.key, target)
+      subject.off?(target)
+    end
+
+    it "returns the opposite boolean of the result of run" do
+      rule = double('rule')
+      target = double('target')
+      result = false
+      subject.instance_variable_set(:@rule, rule)
+      allow(feature).to receive(:key).and_return("key")
+      allow(rule).to receive(:run).and_return(result)
+      expect(subject.off?(target)).to eq(true)
+    end
+  end
+
   describe "#to_s" do
     context "when based on boolean rule" do
       it "returns a human readable string representation of the feature including value" do


### PR DESCRIPTION
I did this because I want a way to ask if a feature is `off?` not just `on?`.
This is a little sugar but it will be helpful in some situations. I see this
as helpful when you are changing behavior.

Some examples would be:

```ruby
do_some_stuff if Togls.feature(:new_feature).off? && some_other_conditional

#or

if Togls.feature(:new_feature).off?
 do_old_stuff
end
```