### PR TITLE
Make Togls.feature create empty toggle registry

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Fixed #19, exceptions happened on evaluation after setting
+  `Togls.features = nil`
+
 ### v2.0.0
 
 * Add ability to create empty feature toggle set via `Togls.features`

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -38,6 +38,10 @@ module Togls
   end
   
   def self.feature(key)
+    if @feature_toggle_registry.nil?
+      @feature_toggle_registry = FeatureToggleRegistry.new
+    end
+
     return @feature_toggle_registry.get(key)
   end
 

--- a/spec/lib/togls_spec.rb
+++ b/spec/lib/togls_spec.rb
@@ -34,6 +34,14 @@ describe Togls do
   end
 
   describe ".feature" do
+    context "when features have NOT been defined" do
+      it "creates a new empty feature toggle registry" do
+        Togls.features = nil
+        expect(Togls::FeatureToggleRegistry).to receive(:new).and_call_original
+        Togls.feature("key")
+      end
+    end
+
     it "returns the feature toggle identified by the key" do
       feature_registry = instance_double Togls::FeatureToggleRegistry 
       Togls.instance_variable_set(:@feature_toggle_registry, feature_registry)


### PR DESCRIPTION
Why you made the change:

I did so that there wouldn't be a way from the external API screw
yourself by having a nil feature toggle registry. More specifically,
prior to this if you were to set `Togls.features = nil` and then try and
evaluate a feature toggle it would throw an exception, :-). This
resolves issue #19.