### PR TITLE
Make env override use true/false

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Fixed issue #21, env variable override wasn't falling through to in
+  code defined memory value.
+
 ### v2.1.0
 
 * Fixed #19, exceptions happened on evaluation after setting

--- a/lib/togls/toggle_repository_drivers/env_override_driver.rb
+++ b/lib/togls/toggle_repository_drivers/env_override_driver.rb
@@ -9,9 +9,11 @@ module Togls
           if ENV[toggle_env_key(toggle_id)] == "true"
             return { "feature_id" => toggle_id,
                      "rule_id" => Togls::Helpers.sha1(Togls::Rules::Boolean, true) }
-          else
+          elsif ENV[toggle_env_key(toggle_id)] == "false"
             return { "feature_id" => toggle_id,
                      "rule_id" => Togls::Helpers.sha1(Togls::Rules::Boolean, false) }
+          else
+            return nil
           end
         else
           return nil

--- a/spec/features/togls_spec.rb
+++ b/spec/features/togls_spec.rb
@@ -120,6 +120,22 @@ describe "Togl" do
         expect(Togls.feature(:test).on?).to eq(true)
       end
     end
+
+    context "when env variable feature override is other than true/false" do
+      after do
+        ENV.delete("TOGLS_TEST")
+      end
+
+      it "feature falls back to in memory store value" do
+        Togls.features do
+          feature(:test, "some human readable description").on
+        end
+
+        ENV["TOGLS_TEST"] = "aeuaoeuaoeuauaueoauaauoe"
+
+        expect(Togls.feature(:test).on?).to eq(true)
+      end
+    end
   end
 
   describe "reviewing feature toggle" do

--- a/spec/lib/togls/toggle_repository_drivers/env_override_driver_spec.rb
+++ b/spec/lib/togls/toggle_repository_drivers/env_override_driver_spec.rb
@@ -18,7 +18,7 @@ describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
   describe "#get" do
     context "when environment toggle isn't set" do
       before do
-        ENV["TOGLS_SOME_TOGGLE_ID"] = nil
+        ENV.delete("TOGLS_SOME_TOGGLE_ID")
       end
 
       it "returns nil" do
@@ -38,7 +38,7 @@ describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
         end
       end
 
-      context "when it is not true" do
+      context "when it is false" do
         before do
           ENV["TOGLS_SOME_TOGGLE_ID"] = "false"
         end
@@ -46,6 +46,16 @@ describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
         it "returns Togls::Rules::Boolean false toggle data" do
           expect(subject.get("some_toggle_id")).to eq({ "feature_id" => "some_toggle_id",
                      "rule_id" => Togls::Helpers.sha1(Togls::Rules::Boolean, false) })
+        end
+      end
+
+      context "when it is not true/false" do
+        before do
+          ENV["TOGLS_SOME_TOGGLE_ID"] = "aeuaeouaoeuaeuaou"
+        end
+
+        it "returns nil" do
+          expect(subject.get("some_toggle_id")).to be_nil
         end
       end
     end


### PR DESCRIPTION
Why you made the change:

I did this so that the only valid values for an environment variable
override are true/false. This means that any other value than true or
false will now result in the feature toggle falling back to the in
memory value for that feature toggle. Issue #21.

@RyanHedges @BRIMIL01 I could use a peer review on this, :-)