### PR TITLE
Make Togls drivers thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Changed Togls to be thread-safe
 * Added Togls::TestToggleRegistry class for initializing test state
 * Added ability to create additional toggle registries
 

--- a/lib/togls/feature_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/feature_repository_drivers/in_memory_driver.rb
@@ -1,16 +1,23 @@
+require 'thread'
+
 module Togls
   module FeatureRepositoryDrivers
     class InMemoryDriver
       def initialize
         @features = {}
+        @features_lock = Mutex.new
       end
 
       def store(feature_id, feature_data)
-        @features[feature_id] = feature_data
+        @features_lock.synchronize do
+          @features[feature_id] = feature_data
+        end
       end
 
       def get(feature_id)
-        @features[feature_id]
+        @features_lock.synchronize do
+          @features[feature_id]
+        end
       end
     end
   end

--- a/lib/togls/rule_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/rule_repository_drivers/in_memory_driver.rb
@@ -1,16 +1,23 @@
+require 'thread'
+
 module Togls
   module RuleRepositoryDrivers
     class InMemoryDriver
       def initialize
         @rules = {}
+        @rules_lock = Mutex.new
       end
 
       def store(rule_id, rule_data)
-        @rules[rule_id] = rule_data
+        @rules_lock.synchronize do
+          @rules[rule_id] = rule_data
+        end
       end
       
       def get(rule_id)
-        @rules[rule_id]
+        @rules_lock.synchronize do
+          @rules[rule_id]
+        end
       end
     end
   end

--- a/lib/togls/toggle_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/toggle_repository_drivers/in_memory_driver.rb
@@ -1,20 +1,29 @@
+require 'thread'
+
 module Togls
   module ToggleRepositoryDrivers
     class InMemoryDriver
       def initialize
         @toggles = {}
+        @toggles_lock = Mutex.new
       end
 
       def store(toggle_id, toggle_data)
-        @toggles[toggle_id] = toggle_data
+        @toggles_lock.synchronize do
+          @toggles[toggle_id] = toggle_data
+        end
       end
 
       def get(toggle_id)
-        @toggles[toggle_id]
+        @toggles_lock.synchronize do
+          @toggles[toggle_id]
+        end
       end
 
       def all
-        @toggles
+        @toggles_lock.synchronize do
+          @toggles
+        end
       end
     end
   end


### PR DESCRIPTION
Why you made the change:

I did this so that Togls could be safely used in a threaded environment. I prime
example of this would be a web application run via puma.

How the change addresses the need:

The only real modifiable state is stored within the drivers so we didn't need
to add any synchronization above the repository driver layers.