### PR TITLE
Remove useless instance variables

### DIFF
--- a/lib/togls/feature_toggle_registry.rb
+++ b/lib/togls/feature_toggle_registry.rb
@@ -12,10 +12,8 @@ module Togls
       @rule_repository = Togls::RuleRepository.new(@rule_repository_drivers)
       @toggle_repository = Togls::ToggleRepository.new(@toggle_repository_drivers,
                                     @feature_repository, @rule_repository)
-      @boolean_true_rule = Togls::Rules::Boolean.new(true)
-      @boolean_false_rule = Togls::Rules::Boolean.new(false)
-      @rule_repository.store(@boolean_false_rule)
-      @rule_repository.store(@boolean_true_rule)
+      @rule_repository.store(Togls::Rules::Boolean.new(true))
+      @rule_repository.store(Togls::Rules::Boolean.new(false))
     end
 
     def self.create(&block)

--- a/lib/togls/test_toggle_registry.rb
+++ b/lib/togls/test_toggle_registry.rb
@@ -11,10 +11,8 @@ module Togls
       @rule_repository = Togls::RuleRepository.new(@rule_repository_drivers)
       @toggle_repository = Togls::ToggleRepository.new(@toggle_repository_drivers,
                                     @feature_repository, @rule_repository)
-      @boolean_true_rule = Togls::Rules::Boolean.new(true)
-      @boolean_false_rule = Togls::Rules::Boolean.new(false)
-      @rule_repository.store(@boolean_false_rule)
-      @rule_repository.store(@boolean_true_rule)
+      @rule_repository.store(Togls::Rules::Boolean.new(true))
+      @rule_repository.store(Togls::Rules::Boolean.new(false))
     end
   end
 end

--- a/spec/lib/togls/feature_toggle_registry_spec.rb
+++ b/spec/lib/togls/feature_toggle_registry_spec.rb
@@ -105,27 +105,11 @@ describe Togls::FeatureToggleRegistry do
       subject
     end
 
-    it "assigns the boolean true rule" do
-      boolean_true_rule = double('boolean true rule')
-      allow(Togls::Rules::Boolean).to receive(:new).with(false)
-      allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
-      allow(Togls::Rules::Boolean).to receive(:new).with(true).and_return(boolean_true_rule)
-      expect(subject.instance_variable_get(:@boolean_true_rule)).to eq(boolean_true_rule)
-    end
-
     it "constructs boolean false rule" do
       allow(Togls::Rules::Boolean).to receive(:new).with(true)
       allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
       expect(Togls::Rules::Boolean).to receive(:new).with(false)
       subject
-    end
-
-    it "assigns the boolean false rule" do
-      boolean_false_rule = double('boolean true rule')
-      allow(Togls::Rules::Boolean).to receive(:new).with(true)
-      allow(Togls::Rules::Boolean).to receive(:new).with(false).and_return(boolean_false_rule)
-      allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
-      expect(subject.instance_variable_get(:@boolean_false_rule)).to eq(boolean_false_rule)
     end
 
     it "stores the boolean false rule" do

--- a/spec/lib/togls/test_toggle_registry_spec.rb
+++ b/spec/lib/togls/test_toggle_registry_spec.rb
@@ -96,27 +96,11 @@ describe Togls::TestToggleRegistry do
       subject
     end
 
-    it "assigns the boolean true rule" do
-      boolean_true_rule = double('boolean true rule')
-      allow(Togls::Rules::Boolean).to receive(:new).with(false)
-      allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
-      allow(Togls::Rules::Boolean).to receive(:new).with(true).and_return(boolean_true_rule)
-      expect(subject.instance_variable_get(:@boolean_true_rule)).to eq(boolean_true_rule)
-    end
-
     it "constructs boolean false rule" do
       allow(Togls::Rules::Boolean).to receive(:new).with(true)
       allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
       expect(Togls::Rules::Boolean).to receive(:new).with(false)
       subject
-    end
-
-    it "assigns the boolean false rule" do
-      boolean_false_rule = double('boolean true rule')
-      allow(Togls::Rules::Boolean).to receive(:new).with(true)
-      allow(Togls::Rules::Boolean).to receive(:new).with(false).and_return(boolean_false_rule)
-      allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
-      expect(subject.instance_variable_get(:@boolean_false_rule)).to eq(boolean_false_rule)
     end
 
     it "stores the boolean false rule" do


### PR DESCRIPTION
Why you made the change:

I made this change to cleanup the code so there is less noise.

How the change addresses the need:

This helps accomplished this goal because it removes instance variables that
were accidentally left in the code base that are not actually used.