### PR TITLE
Bump copyright to include 2016

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Brian Miller, Andrew De Ponte, Ryan Hedges
+Copyright (c) 2015-2016 Brian Miller, Andrew De Ponte, Ryan Hedges
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Why you made the change:

I did this so that it was clear that the copyright spans from 2015 through 2016.