### PR TITLE
Add Marshal to in-memory driver set, get, all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Added: in-memory driver `set`, `get`, `all` Marshaling to correct a threading
+  reference based collision. Fixes issue #35
+
 ### v2.2.0
 
 * Changed Togls to be thread-safe

--- a/lib/togls/feature_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/feature_repository_drivers/in_memory_driver.rb
@@ -14,13 +14,17 @@ module Togls
 
       def store(feature_id, feature_data)
         @features_lock.synchronize do
-          @features[feature_id] = feature_data
+          @features[feature_id] = Marshal.dump(feature_data)
         end
       end
 
       def get(feature_id)
         @features_lock.synchronize do
-          @features[feature_id]
+          if @features.has_key?(feature_id)
+            Marshal.load(@features[feature_id])
+          else
+            nil
+          end
         end
       end
     end

--- a/lib/togls/rule_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/rule_repository_drivers/in_memory_driver.rb
@@ -14,13 +14,17 @@ module Togls
 
       def store(rule_id, rule_data)
         @rules_lock.synchronize do
-          @rules[rule_id] = rule_data
+          @rules[rule_id] = Marshal.dump(rule_data)
         end
       end
 
       def get(rule_id)
         @rules_lock.synchronize do
-          @rules[rule_id]
+          if @rules.has_key?(rule_id)
+            Marshal.load(@rules[rule_id])
+          else
+            nil
+          end
         end
       end
     end

--- a/lib/togls/toggle_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/toggle_repository_drivers/in_memory_driver.rb
@@ -14,20 +14,26 @@ module Togls
 
       def store(toggle_id, toggle_data)
         @toggles_lock.synchronize do
-          @toggles[toggle_id] = toggle_data
+          @toggles[toggle_id] = Marshal.dump(toggle_data)
         end
       end
 
       def get(toggle_id)
         @toggles_lock.synchronize do
-          @toggles[toggle_id]
+          if @toggles.has_key?(toggle_id)
+            Marshal.load(@toggles[toggle_id])
+          else
+            nil
+          end
         end
       end
 
       def all
+        result = {}
         @toggles_lock.synchronize do
-          @toggles
+          @toggles.each_pair { |k, v| result[k] = Marshal.load(v) }
         end
+        result
       end
     end
   end

--- a/spec/togls/feature_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/feature_repository_drivers/in_memory_driver_spec.rb
@@ -12,19 +12,17 @@ describe Togls::FeatureRepositoryDrivers::InMemoryDriver do
     end
   end
 
-  describe "#store" do
-    it "saves the storage payload" do
+  describe "storing and retrieving" do
+    it "saves and retrieves the storage payload" do
       feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
-      subject.store(feature.id, { "key" => "some_feature_key", "description" => "Some Feature Desc" })
-      expect(subject.instance_variable_get(:@features)["some_feature_key"]).to eq({ "key" => "some_feature_key", "description" => "Some Feature Desc" })
+      subject.store(feature.id, { "key" => feature.key, "description" => feature.description })
+      expect(subject.get(feature.id)).to eq({ "key" => feature.key, "description" => feature.description })
     end
-  end
 
-  describe "#get" do
-    it "return feature data identified by an id" do
-      features = subject.instance_variable_get(:@features)
-      features["some_id"] = 'hoopty doopty'
-      expect(subject.get("some_id")).to eq('hoopty doopty')
+    context 'when attempting to retrieve a non stored value' do
+      it 'returns nil' do
+        expect(subject.get('non_existent_key')).to be_nil
+      end
     end
   end
 end

--- a/spec/togls/rule_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/rule_repository_drivers/in_memory_driver_spec.rb
@@ -12,18 +12,16 @@ describe Togls::RuleRepositoryDrivers::InMemoryDriver do
     end
   end
 
-  describe "#store" do
-    it "saves the storage payload" do
+  describe "storing and retrieving" do
+    it "saves the storage payload and retrieves it" do
       subject.store('aeuaoeuoa2342eau', { "klass" => Togls::Rule, "data" => true })
-      expect(subject.instance_variable_get(:@rules)['aeuaoeuoa2342eau']).to eq({ "klass" => Togls::Rule, "data" => true })
+      expect(subject.get('aeuaoeuoa2342eau')).to eq({ "klass" => Togls::Rule, "data" => true })
     end
-  end
 
-  describe "#get" do
-    it "return rule data identified by an id" do
-      rules = subject.instance_variable_get(:@rules)
-      rules["some_id"] = 'hoopty doopty'
-      expect(subject.get("some_id")).to eq('hoopty doopty')
+    context 'when attempting to retrieve a non stored value' do
+      it 'returns nil' do
+        expect(subject.get('non_existent_key')).to be_nil
+      end
     end
   end
 end

--- a/spec/togls/toggle_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/toggle_repository_drivers/in_memory_driver_spec.rb
@@ -12,29 +12,29 @@ describe Togls::ToggleRepositoryDrivers::InMemoryDriver do
     end
   end
 
-  describe "#store" do
-    it "saves the storage payload" do
+  describe "storing and retrieving" do
+    it "saves the storage payload and retrieves it" do
       feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
       toggle = Togls::Toggle.new(feature)
-      toggle_data = double("toggle data")
+      toggle_data = { 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id }
       subject.store(toggle.id, toggle_data)
-      expect(subject.instance_variable_get(:@toggles)[toggle.id])
-        .to eq(toggle_data)
+      expect(subject.get(toggle.id)).to eq({ 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id })
     end
-  end
 
-  describe "#get" do
-    it "return toggle data identified by an id" do
-      toggles = subject.instance_variable_get(:@toggles)
-      toggles["some_id"] = 'hoopty doopty'
-      expect(subject.get("some_id")).to eq('hoopty doopty')
+    context 'when attempting to retrieve a non stored value' do
+      it 'returns nil' do
+        expect(subject.get('non_existent_key')).to be_nil
+      end
     end
   end
 
   describe "#all" do
     it "returns the collection of toggles" do
-      toggles = subject.instance_variable_get(:@toggles)
-      expect(subject.all).to eq(toggles)
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      toggle = Togls::Toggle.new(feature)
+      toggle_data = { 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id }
+      subject.store(toggle.id, toggle_data)
+      expect(subject.all).to eq({"some_feature_key"=>{"feature_id"=>toggle.feature.id, "rule_id"=>toggle.rule.id}})
     end
   end
 end


### PR DESCRIPTION
Why you made the change:

I did this because there was a rare timing issue with multi-threading where
references to sub-hashes and sub-values of a hash that were of certain types
where being incorrectly shared.

How the change addresses the need:

Adding the Marshaling in the set, get, and all methods of the drivers resolves
this issue because it basically causes a deep copy of the objects. It also has
the added benefit of matching the behavior of say the Redis driver and most
others that would also require marshaling.