### PR TITLE
Move feature repository out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ versions, as well as provide a rough history.
 #### Next Release
 
 * Changed: FeatureRepository moved from Registry to Registry Manager 
-* Changed: `TestToggleRegistry.new` to accept optional block
-* Changed: `FeatureToggleRegistry.new` to accept optional block
 * Removed: `FeatureToggleRegistry.create` and `TestToggleRegistry.create`
 
 ### v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Changed: `TestToggleRegistry.new` to accept optional block
+* Changed: `FeatureToggleRegistry.new` to accept optional block
+* Removed: `FeatureToggleRegistry.create` and `TestToggleRegistry.create`
+
 ### v2.2.1
 
 * Added: in-memory driver `set`, `get`, `all` Marshaling to correct a threading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ versions, as well as provide a rough history.
 * Added: `FeatureToggleRegistryManager` methods, `enable_test_mode` &
   `disable_test_mode`
 * Removed: `features=` setter
-* Changed: FeatureRepository moved from Registry to Registry Manager 
+* Changed: `FeatureRepository` moved from `Registry` to `RegistryManager` 
 * Removed: `FeatureToggleRegistry.create` and `TestToggleRegistry.create`
 
 ### v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ versions, as well as provide a rough history.
 * Removed: `features=` setter
 * Changed: `FeatureRepository` moved from `Registry` to `RegistryManager` 
 * Removed: `FeatureToggleRegistry.create` and `TestToggleRegistry.create`
+* Changed: `ReleaseToggleRegistryManager` to `FeatureToggleRegistryManager`
 
 ### v2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Added: `FeatureToggleRegistryManager` methods, `enable_test_mode` &
+  `disable_test_mode`
+* Removed: `features=` setter
 * Changed: FeatureRepository moved from Registry to Registry Manager 
 * Removed: `FeatureToggleRegistry.create` and `TestToggleRegistry.create`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Changed: FeatureRepository moved from Registry to Registry Manager 
 * Changed: `TestToggleRegistry.new` to accept optional block
 * Changed: `FeatureToggleRegistry.new` to accept optional block
 * Removed: `FeatureToggleRegistry.create` and `TestToggleRegistry.create`

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -20,12 +20,12 @@ require 'togls/null_toggle'
 require 'togls/rule'
 require 'togls/rules'
 require 'logger'
-require 'togls/release_toggle_registry_manager'
+require 'togls/feature_toggle_registry_manager'
 
 # Togls
 #
 # Togls is the primary interface to the out of the box toggle registry. It is
 # the namespace the DSL is exposed under.
 module Togls
-  include ReleaseToggleRegistryManager
+  include FeatureToggleRegistryManager
 end

--- a/lib/togls/feature_toggle_registry.rb
+++ b/lib/togls/feature_toggle_registry.rb
@@ -7,7 +7,7 @@ module Togls
   # respective entities. This plays a significant portion in the primary DSL as
   # well.
   class FeatureToggleRegistry
-    def initialize
+    def initialize(&block)
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new,
         Togls::ToggleRepositoryDrivers::EnvOverrideDriver.new]
@@ -22,12 +22,7 @@ module Togls
         @toggle_repository_drivers, @feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
-    end
-
-    def self.create(&block)
-      feature_toggle_registry = new
-      feature_toggle_registry.instance_eval(&block)
-      feature_toggle_registry
+      self.instance_eval(&block) if block_given?
     end
 
     def expand(&block)

--- a/lib/togls/feature_toggle_registry.rb
+++ b/lib/togls/feature_toggle_registry.rb
@@ -8,7 +8,6 @@ module Togls
   # well.
   class FeatureToggleRegistry
     def initialize(feature_repository, &block)
-      @feature_repository = feature_repository
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new,
         Togls::ToggleRepositoryDrivers::EnvOverrideDriver.new]
@@ -16,7 +15,7 @@ module Togls
         [Togls::RuleRepositoryDrivers::InMemoryDriver.new]
       @rule_repository = Togls::RuleRepository.new(@rule_repository_drivers)
       @toggle_repository = Togls::ToggleRepository.new(
-        @toggle_repository_drivers, @feature_repository, @rule_repository)
+        @toggle_repository_drivers, feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
       self.instance_eval(&block) if block_given?

--- a/lib/togls/feature_toggle_registry.rb
+++ b/lib/togls/feature_toggle_registry.rb
@@ -7,7 +7,7 @@ module Togls
   # respective entities. This plays a significant portion in the primary DSL as
   # well.
   class FeatureToggleRegistry
-    def initialize(feature_repository, &block)
+    def initialize(feature_repository)
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new,
         Togls::ToggleRepositoryDrivers::EnvOverrideDriver.new]
@@ -18,7 +18,6 @@ module Togls
         @toggle_repository_drivers, feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
-      self.instance_eval(&block) if block_given?
     end
 
     def expand(&block)

--- a/lib/togls/feature_toggle_registry.rb
+++ b/lib/togls/feature_toggle_registry.rb
@@ -7,16 +7,13 @@ module Togls
   # respective entities. This plays a significant portion in the primary DSL as
   # well.
   class FeatureToggleRegistry
-    def initialize(&block)
+    def initialize(feature_repository, &block)
+      @feature_repository = feature_repository
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new,
         Togls::ToggleRepositoryDrivers::EnvOverrideDriver.new]
-      @feature_repository_drivers =
-        [Togls::FeatureRepositoryDrivers::InMemoryDriver.new]
       @rule_repository_drivers =
         [Togls::RuleRepositoryDrivers::InMemoryDriver.new]
-      @feature_repository = Togls::FeatureRepository.new(
-        @feature_repository_drivers)
       @rule_repository = Togls::RuleRepository.new(@rule_repository_drivers)
       @toggle_repository = Togls::ToggleRepository.new(
         @toggle_repository_drivers, @feature_repository, @rule_repository)

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -1,17 +1,17 @@
 module Togls
-  # Release Toggle Registry Manager
+  # Feature Toggle Registry Manager
   #
   # This is the primary DSL interface. It provides a DSL to facilitate housing
   # and managing a toggle registry.
-  module ReleaseToggleRegistryManager
+  module FeatureToggleRegistryManager
     def self.included(mod)
       mod.extend(ClassMethods)
     end
 
-    # Release Toggle Registry Manager Class Methods
+    # Feature Toggle Registry Manager Class Methods
     #
     # The class methods that should be extended onto the module/class when
-    # ReleaseToggleRegistryManager is included.
+    # FeatureToggleRegistryManager is included.
     module ClassMethods
       def features(&block)
         if @feature_toggle_registry.nil?

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -14,13 +14,8 @@ module Togls
     # FeatureToggleRegistryManager is included.
     module ClassMethods
       def features(&block)
-        if @feature_toggle_registry.nil?
-          @feature_toggle_registry = FeatureToggleRegistry.new
-        end
-
-        @feature_toggle_registry.expand(&block) if block
-
-        @feature_toggle_registry
+        feature_toggle_registry.expand(&block) if block
+        feature_toggle_registry
       end
 
       def features=(feature_toggle_registry)
@@ -28,15 +23,20 @@ module Togls
       end
 
       def feature(key)
-        if @feature_toggle_registry.nil?
-          @feature_toggle_registry = FeatureToggleRegistry.new
-        end
-
-        @feature_toggle_registry.get(key)
+        feature_toggle_registry.get(key)
       end
 
       def logger
         @logger ||= Logger.new(STDOUT)
+      end
+
+      private
+
+      def feature_toggle_registry
+        if @feature_toggle_registry.nil?
+          @feature_toggle_registry = FeatureToggleRegistry.new
+        end
+        @feature_toggle_registry
       end
     end
   end

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -34,9 +34,17 @@ module Togls
 
       def feature_toggle_registry
         if @feature_toggle_registry.nil?
-          @feature_toggle_registry = FeatureToggleRegistry.new
+          @feature_toggle_registry = FeatureToggleRegistry.new(feature_repository)
         end
         @feature_toggle_registry
+      end
+
+      def feature_repository
+        if @feature_repository.nil?
+          feature_repository_drivers = [Togls::FeatureRepositoryDrivers::InMemoryDriver.new]
+          @feature_repository = Togls::FeatureRepository.new(feature_repository_drivers)
+        end
+        @feature_repository
       end
     end
   end

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -38,7 +38,7 @@ module Togls
       private
 
       def test_toggle_registry
-        TestToggleRegistry.new(feature_repository)
+        TestToggleRegistry.new
       end
 
       def feature_toggle_registry

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -18,10 +18,6 @@ module Togls
         feature_toggle_registry
       end
 
-      def features=(feature_toggle_registry)
-        @feature_toggle_registry = feature_toggle_registry
-      end
-
       def feature(key)
         feature_toggle_registry.get(key)
       end
@@ -30,7 +26,20 @@ module Togls
         @logger ||= Logger.new(STDOUT)
       end
 
+      def enable_test_mode
+        @previous_feature_toggle_registry = @feature_toggle_registry
+        @feature_toggle_registry = test_toggle_registry
+      end
+
+      def disable_test_mode
+        @feature_toggle_registry = @previous_feature_toggle_registry
+      end
+
       private
+
+      def test_toggle_registry
+        TestToggleRegistry.new(feature_repository)
+      end
 
       def feature_toggle_registry
         if @feature_toggle_registry.nil?

--- a/lib/togls/test_toggle_registry.rb
+++ b/lib/togls/test_toggle_registry.rb
@@ -7,14 +7,18 @@ module Togls
   # this registry only uses in-memory drivers and the FeatureToggleRegistry uses
   # in-memory drivers as well as the environment override drivers.
   class TestToggleRegistry < FeatureToggleRegistry
-    def initialize(feature_repository)
+    def initialize
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new]
+      @feature_repository_drivers =
+        [Togls::FeatureRepositoryDrivers::InMemoryDriver.new]
       @rule_repository_drivers =
         [Togls::RuleRepositoryDrivers::InMemoryDriver.new]
+      @feature_repository = Togls::FeatureRepository.new(
+        @feature_repository_drivers)
       @rule_repository = Togls::RuleRepository.new(@rule_repository_drivers)
       @toggle_repository = Togls::ToggleRepository.new(
-        @toggle_repository_drivers, feature_repository, @rule_repository)
+        @toggle_repository_drivers, @feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
     end

--- a/lib/togls/test_toggle_registry.rb
+++ b/lib/togls/test_toggle_registry.rb
@@ -7,7 +7,7 @@ module Togls
   # this registry only uses in-memory drivers and the FeatureToggleRegistry uses
   # in-memory drivers as well as the environment override drivers.
   class TestToggleRegistry < FeatureToggleRegistry
-    def initialize(&block)
+    def initialize
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new]
       @feature_repository_drivers =
@@ -21,7 +21,6 @@ module Togls
         @toggle_repository_drivers, @feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
-      self.instance_eval(&block) if block_given?
     end
   end
 end

--- a/lib/togls/test_toggle_registry.rb
+++ b/lib/togls/test_toggle_registry.rb
@@ -7,18 +7,14 @@ module Togls
   # this registry only uses in-memory drivers and the FeatureToggleRegistry uses
   # in-memory drivers as well as the environment override drivers.
   class TestToggleRegistry < FeatureToggleRegistry
-    def initialize
+    def initialize(feature_repository)
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new]
-      @feature_repository_drivers =
-        [Togls::FeatureRepositoryDrivers::InMemoryDriver.new]
       @rule_repository_drivers =
         [Togls::RuleRepositoryDrivers::InMemoryDriver.new]
-      @feature_repository = Togls::FeatureRepository.new(
-        @feature_repository_drivers)
       @rule_repository = Togls::RuleRepository.new(@rule_repository_drivers)
       @toggle_repository = Togls::ToggleRepository.new(
-        @toggle_repository_drivers, @feature_repository, @rule_repository)
+        @toggle_repository_drivers, feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
     end

--- a/lib/togls/test_toggle_registry.rb
+++ b/lib/togls/test_toggle_registry.rb
@@ -7,7 +7,7 @@ module Togls
   # this registry only uses in-memory drivers and the FeatureToggleRegistry uses
   # in-memory drivers as well as the environment override drivers.
   class TestToggleRegistry < FeatureToggleRegistry
-    def initialize
+    def initialize(&block)
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new]
       @feature_repository_drivers =
@@ -21,6 +21,7 @@ module Togls
         @toggle_repository_drivers, @feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
+      self.instance_eval(&block) if block_given?
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'togls'
 require 'pry'
 
 RSpec.configure do |c|
-  c.before(:example) do
-    Togls.features = nil
+  c.before(:each) do
+    Togls.instance_variable_set(:@feature_toggle_registry, nil)
   end
 end

--- a/spec/togls/feature_toggle_registry_manager_spec.rb
+++ b/spec/togls/feature_toggle_registry_manager_spec.rb
@@ -27,18 +27,10 @@ describe Togls::FeatureToggleRegistryManager do
     end
   end
 
-  describe ".features=" do
-    it "assigns the given feature toggle registry to @feature_toggle_registry" do
-      feature_toggle_registry = double('feature toggle registry')
-      klass.features = feature_toggle_registry
-      expect(klass.features).to eq(feature_toggle_registry)
-    end
-  end
-
   describe ".feature" do
     context "when features have NOT been defined" do
       it "creates a new empty feature toggle registry" do
-        klass.features = nil
+        klass.instance_variable_set(:@feature_toggle_registry, nil)
         expect(Togls::FeatureToggleRegistry).to receive(:new).and_call_original
         klass.feature("key")
       end
@@ -59,6 +51,33 @@ describe Togls::FeatureToggleRegistryManager do
       allow(Logger).to receive(:new).with(STDOUT).and_return(logger)
       expect(klass.logger).to eq(logger)
       expect(klass.logger).to eq(logger)
+    end
+  end
+
+  describe '.enable_test_mode' do
+    it 'stores the current feature toggle registry' do
+      test_registry = double('test registry')
+      klass.instance_variable_set(:@feature_toggle_registry, test_registry)
+      klass.enable_test_mode
+      expect(klass.instance_variable_get(:@previous_feature_toggle_registry)).to\
+        eq(test_registry)
+    end
+
+    it 'sets the feature toggle registry to the test toggle registry' do
+      test_registry = double('test registry')
+      allow(klass).to receive(:test_toggle_registry).and_return(test_registry)
+      klass.enable_test_mode
+      expect(klass.instance_variable_get(:@feature_toggle_registry)).to eq(test_registry)
+    end
+  end
+
+  describe '.disable_test_mode' do
+    it 'restores the feature toggle registry to prev stored value' do
+      test_registry = double('test registry')
+      klass.instance_variable_set(:@previous_feature_toggle_registry, test_registry)
+      klass.disable_test_mode
+      expect(klass.instance_variable_get(:@feature_toggle_registry)).to\
+        eq(test_registry)
     end
   end
 end

--- a/spec/togls/feature_toggle_registry_manager_spec.rb
+++ b/spec/togls/feature_toggle_registry_manager_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Togls::ReleaseToggleRegistryManager do
-  let(:klass) { Class.new { include Togls::ReleaseToggleRegistryManager } }
+describe Togls::FeatureToggleRegistryManager do
+  let(:klass) { Class.new { include Togls::FeatureToggleRegistryManager } }
 
   describe ".features" do
     context "when features have NOT been defined" do

--- a/spec/togls/feature_toggle_registry_spec.rb
+++ b/spec/togls/feature_toggle_registry_spec.rb
@@ -135,35 +135,23 @@ describe Togls::FeatureToggleRegistry do
       expect(rule_repository).to receive(:store).with(boolean_true_rule)
       subject
     end
-  end
 
-  describe ".create" do
-    it "creates a new instance of a feature toggle registry" do
-      registry = double('registry')
-      expect(Togls::FeatureToggleRegistry).to receive(:new).and_return(registry)
-      b = Proc.new {}
-      Togls::FeatureToggleRegistry.create(&b)
-    end
-
-    context "when block given" do
-      it "calls instance eval with the passed block" do
-        registry = double('registry')
-        allow(Togls::FeatureToggleRegistry).to receive(:new).and_return(registry)
+    context 'when given a block' do
+      it "creates a new instance of a feature toggle registry" do
         b = Proc.new {}
-        expect(registry).to receive(:instance_eval).and_yield(&b)
-        Togls::FeatureToggleRegistry.create(&b)
+        Togls::FeatureToggleRegistry.new(&b)
       end
-    end
 
-    it "returns a configured feature registry object" do
-      b = Proc.new {}
-      expect(Togls::FeatureToggleRegistry.create(&b)).to be_a(Togls::FeatureToggleRegistry)
+      it "returns a configured feature registry object" do
+        b = Proc.new {}
+        expect(Togls::FeatureToggleRegistry.new(&b)).to be_a(Togls::FeatureToggleRegistry)
+      end
     end
   end
 
   describe "#expand" do
     it "instance evals the provided block" do
-      registry = Togls::FeatureToggleRegistry.create do
+      registry = Togls::FeatureToggleRegistry.new do
         feature(:foo, "some description").on
       end
 
@@ -174,7 +162,7 @@ describe Togls::FeatureToggleRegistry do
     end
 
     it "returns the feature toggle repository" do
-      registry = Togls::FeatureToggleRegistry.create do
+      registry = Togls::FeatureToggleRegistry.new do
         feature(:foo, "some description").on
       end
 

--- a/spec/togls/feature_toggle_registry_spec.rb
+++ b/spec/togls/feature_toggle_registry_spec.rb
@@ -124,7 +124,8 @@ describe Togls::FeatureToggleRegistry do
 
   describe "#expand" do
     it "instance evals the provided block" do
-      registry = Togls::FeatureToggleRegistry.new(feature_repository) do
+      registry = Togls::FeatureToggleRegistry.new(feature_repository)
+      registry.expand do
         feature(:foo, "some description").on
       end
 
@@ -135,7 +136,8 @@ describe Togls::FeatureToggleRegistry do
     end
 
     it "returns the feature toggle repository" do
-      registry = Togls::FeatureToggleRegistry.new(feature_repository) do
+      registry = Togls::FeatureToggleRegistry.new(feature_repository)
+      registry.expand do
         feature(:foo, "some description").on
       end
 

--- a/spec/togls/feature_toggle_registry_spec.rb
+++ b/spec/togls/feature_toggle_registry_spec.rb
@@ -113,9 +113,6 @@ describe Togls::FeatureToggleRegistry do
   describe "#expand" do
     it "instance evals the provided block" do
       registry = Togls::FeatureToggleRegistry.new(feature_repository)
-      registry.expand do
-        feature(:foo, "some description").on
-      end
 
       expect(registry).to receive(:instance_eval)
       registry.expand do
@@ -125,9 +122,6 @@ describe Togls::FeatureToggleRegistry do
 
     it "returns the feature toggle repository" do
       registry = Togls::FeatureToggleRegistry.new(feature_repository)
-      registry.expand do
-        feature(:foo, "some description").on
-      end
 
       block = Proc.new {}
       expect(registry.expand(&block)).to eq(registry)

--- a/spec/togls/feature_toggle_registry_spec.rb
+++ b/spec/togls/feature_toggle_registry_spec.rb
@@ -108,18 +108,6 @@ describe Togls::FeatureToggleRegistry do
       expect(rule_repository).to receive(:store).with(boolean_true_rule)
       subject
     end
-
-    context 'when given a block' do
-      it "creates a new instance of a feature toggle registry" do
-        b = Proc.new {}
-        Togls::FeatureToggleRegistry.new(feature_repository, &b)
-      end
-
-      it "returns a configured feature registry object" do
-        b = Proc.new {}
-        expect(Togls::FeatureToggleRegistry.new(feature_repository, &b)).to be_a(Togls::FeatureToggleRegistry)
-      end
-    end
   end
 
   describe "#expand" do

--- a/spec/togls/test_toggle_registry_spec.rb
+++ b/spec/togls/test_toggle_registry_spec.rb
@@ -126,37 +126,25 @@ describe Togls::TestToggleRegistry do
       expect(rule_repository).to receive(:store).with(boolean_true_rule)
       subject
     end
-  end
 
-  describe ".create" do
-    subject { Togls::TestToggleRegistry }
+    context 'when given a block' do
+      subject { Togls::TestToggleRegistry }
 
-    it "creates a new instance of a feature toggle registry" do
-      registry = double('registry')
-      expect(subject).to receive(:new).and_return(registry)
-      b = Proc.new {}
-      subject.create(&b)
-    end
-
-    context "when block given" do
-      it "calls instance eval with the passed block" do
-        registry = double('registry')
-        allow(subject).to receive(:new).and_return(registry)
+      it "creates a new instance of a feature toggle registry" do
         b = Proc.new {}
-        expect(registry).to receive(:instance_eval).and_yield(&b)
-        subject.create(&b)
+        subject.new(&b)
       end
-    end
 
-    it "returns a configured feature registry object" do
-      b = Proc.new {}
-      expect(subject.create(&b)).to be_a(subject)
+      it "returns a configured feature registry object" do
+        b = Proc.new {}
+        expect(subject.new(&b)).to be_a(subject)
+      end
     end
   end
 
   describe "#expand" do
     it "instance evals the provided block" do
-      registry = Togls::TestToggleRegistry.create do
+      registry = Togls::TestToggleRegistry.new do
         feature(:foo, "some description").on
       end
 
@@ -167,7 +155,7 @@ describe Togls::TestToggleRegistry do
     end
 
     it "returns the feature toggle repository" do
-      registry = Togls::TestToggleRegistry.create do
+      registry = Togls::TestToggleRegistry.new do
         feature(:foo, "some description").on
       end
 

--- a/spec/togls/test_toggle_registry_spec.rb
+++ b/spec/togls/test_toggle_registry_spec.rb
@@ -131,9 +131,6 @@ describe Togls::TestToggleRegistry do
   describe "#expand" do
     it "instance evals the provided block" do
       registry = Togls::TestToggleRegistry.new
-      registry.expand do
-        feature(:foo, "some description").on
-      end
 
       expect(registry).to receive(:instance_eval)
       registry.expand do
@@ -143,9 +140,6 @@ describe Togls::TestToggleRegistry do
 
     it "returns the feature toggle repository" do
       registry = Togls::TestToggleRegistry.new
-      registry.expand do
-        feature(:foo, "some description").on
-      end
 
       block = Proc.new {}
       expect(registry.expand(&block)).to eq(registry)

--- a/spec/togls/test_toggle_registry_spec.rb
+++ b/spec/togls/test_toggle_registry_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Togls::TestToggleRegistry do
-  subject { Togls::TestToggleRegistry.new }
+  let!(:feature_repository) { Togls::FeatureRepository.new([Togls::FeatureRepositoryDrivers::InMemoryDriver.new]) }
+  subject { Togls::TestToggleRegistry.new(feature_repository) }
 
   describe "#initalize" do
     it "constructs the ToggleRepository InMemoryDriver" do
@@ -13,18 +14,6 @@ describe Togls::TestToggleRegistry do
       driver_one = double('driver in memory')
       allow(Togls::ToggleRepositoryDrivers::InMemoryDriver).to receive(:new).and_return(driver_one)
       expect(subject.instance_variable_get(:@toggle_repository_drivers)).to eq([driver_one])
-    end
-
-    it "constructs the FeatureRepository InMemoryDriver" do
-      expect(Togls::FeatureRepositoryDrivers::InMemoryDriver).to receive(:new)
-      subject
-    end
-
-    it "assigns the feature repository drivers" do
-      driver = double('driver')
-      allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
-      allow(Togls::FeatureRepositoryDrivers::InMemoryDriver).to receive(:new).and_return(driver)
-      expect(subject.instance_variable_get(:@feature_repository_drivers)).to eq([driver])
     end
 
     it "constructs the RuleRepository InMemoryDriver" do
@@ -39,20 +28,6 @@ describe Togls::TestToggleRegistry do
       allow(Togls::RuleRepository).to receive(:new).and_return(double.as_null_object)
       allow(Togls::RuleRepositoryDrivers::InMemoryDriver).to receive(:new).and_return(driver_one)
       expect(subject.instance_variable_get(:@rule_repository_drivers)).to eq([driver_one])
-    end
-
-    it "constructs a feature repository" do
-      allow(Togls::FeatureRepository).to receive(:new)
-      driver = double('driver')
-      allow(Togls::FeatureRepositoryDrivers::InMemoryDriver).to receive(:new).and_return(driver)
-      subject
-      expect(Togls::FeatureRepository).to have_received(:new).with([driver])
-    end
-
-    it "assigns the constructed feature repository" do
-      feature_repository = double('feature repository')
-      allow(Togls::FeatureRepository).to receive(:new).and_return(feature_repository)
-      expect(subject.instance_variable_get(:@feature_repository)).to eq(feature_repository)
     end
 
     it "constructs a rule repository" do
@@ -72,8 +47,6 @@ describe Togls::TestToggleRegistry do
 
     it "constructs a toggle repository" do
       allow(Togls::ToggleRepository).to receive(:new)
-      feature_repository = double('feature repository')
-      allow(Togls::FeatureRepository).to receive(:new).and_return(feature_repository)
       rule_repository = double('rule repository').as_null_object
       allow(Togls::RuleRepository).to receive(:new).and_return(rule_repository)
       driver_one = double('driver in memory')
@@ -126,25 +99,11 @@ describe Togls::TestToggleRegistry do
       expect(rule_repository).to receive(:store).with(boolean_true_rule)
       subject
     end
-
-    context 'when given a block' do
-      subject { Togls::TestToggleRegistry }
-
-      it "creates a new instance of a feature toggle registry" do
-        b = Proc.new {}
-        subject.new(&b)
-      end
-
-      it "returns a configured feature registry object" do
-        b = Proc.new {}
-        expect(subject.new(&b)).to be_a(subject)
-      end
-    end
   end
 
   describe "#expand" do
     it "instance evals the provided block" do
-      registry = Togls::TestToggleRegistry.new
+      registry = Togls::TestToggleRegistry.new(feature_repository)
       registry.expand do
         feature(:foo, "some description").on
       end
@@ -156,7 +115,7 @@ describe Togls::TestToggleRegistry do
     end
 
     it "returns the feature toggle repository" do
-      registry = Togls::TestToggleRegistry.new
+      registry = Togls::TestToggleRegistry.new(feature_repository)
       registry.expand do
         feature(:foo, "some description").on
       end

--- a/spec/togls/test_toggle_registry_spec.rb
+++ b/spec/togls/test_toggle_registry_spec.rb
@@ -144,7 +144,8 @@ describe Togls::TestToggleRegistry do
 
   describe "#expand" do
     it "instance evals the provided block" do
-      registry = Togls::TestToggleRegistry.new do
+      registry = Togls::TestToggleRegistry.new
+      registry.expand do
         feature(:foo, "some description").on
       end
 
@@ -155,7 +156,8 @@ describe Togls::TestToggleRegistry do
     end
 
     it "returns the feature toggle repository" do
-      registry = Togls::TestToggleRegistry.new do
+      registry = Togls::TestToggleRegistry.new
+      registry.expand do
         feature(:foo, "some description").on
       end
 

--- a/spec/togls/test_toggle_registry_spec.rb
+++ b/spec/togls/test_toggle_registry_spec.rb
@@ -126,20 +126,6 @@ describe Togls::TestToggleRegistry do
       expect(rule_repository).to receive(:store).with(boolean_true_rule)
       subject
     end
-
-    context 'when given a block' do
-      subject { Togls::TestToggleRegistry }
-
-      it "creates a new instance of a feature toggle registry" do
-        b = Proc.new {}
-        subject.new(&b)
-      end
-
-      it "returns a configured feature registry object" do
-        b = Proc.new {}
-        expect(subject.new(&b)).to be_a(subject)
-      end
-    end
   end
 
   describe "#expand" do

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -55,7 +55,7 @@ describe "Togl" do
 
   describe "set the feature toggle registry" do
     it "uses the specified feature toggle registry" do
-      Togls.features = Togls::TestToggleRegistry.new
+      Togls.enable_test_mode
       Togls.features do
         feature(:foo, "some magic foo").on
       end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -55,7 +55,8 @@ describe "Togl" do
 
   describe "set the feature toggle registry" do
     it "uses the specified feature toggle registry" do
-      Togls.features = Togls::TestToggleRegistry.new do
+      Togls.features = Togls::TestToggleRegistry.new
+      Togls.features do
         feature(:foo, "some magic foo").on
       end
 

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -55,7 +55,7 @@ describe "Togl" do
 
   describe "set the feature toggle registry" do
     it "uses the specified feature toggle registry" do
-      Togls.features = Togls::FeatureToggleRegistry.create do
+      Togls.features = Togls::TestToggleRegistry.new do
         feature(:foo, "some magic foo").on
       end
 

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -165,7 +165,7 @@ off - test3 - test3 readable description
       end
 
       klass = Class.new do
-        include Togls::ReleaseToggleRegistryManager
+        include Togls::FeatureToggleRegistryManager
       end
 
       klass.features do


### PR DESCRIPTION
### Move FeatureRepository from Registry to Manager

Why you made the change:

I did this so that a single feature repository would be able to be
shared across multiple repositories potentially.

### Remove registry create method

Why you made the change:

I did this because it was duplicative of the responsibility of building
a registry. I modified the initialize method of both the
FeatureToggleRegistry class and the TestToggleRegistry class to accept
on optional block so that they can be used in a similar fashion to how
create was previously used. This also will allow a registry to have
arguments during construction in addition to the block that created
didn't really allow for.

### Extract feature_toggle_registry method

Why you made the change:

I did this so that the memoization and lazy creation of the
FeatureToggleRegistry that was previously duplicated in two places could
be streamlined into one private method being responsible for it.

### Rename ReleaseToggleRegistryManager

Why you made the change:

I did this because I wanted to conceptually represent potentially more
than just release toggles. Therefore, I renamed it to
FeatureToggleRegistryManager which is more generic name as it includes
all different types of toggles.
