### PR TITLE
Change Togls.features to Togls.release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Changed: `Togls.features` to `Togls.release`
 * Changed: Renamed `FeatureToggleRegistry` to `ReleaseToggleRegistry`
 * Added: `FeatureToggleRegistryManager` methods, `enable_test_mode` &
   `disable_test_mode`

--- a/lib/tasks/togls.rake
+++ b/lib/tasks/togls.rake
@@ -2,7 +2,7 @@ namespace :togls do
   desc 'Output all features including status (on, off, ? - unknown due to' \
    ' complex rule), key, description'
   task :features do
-    Togls.features.all.each do |toggle|
+    Togls.release.all.each do |toggle|
       puts toggle.to_s
     end
   end

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -13,7 +13,7 @@ module Togls
     # The class methods that should be extended onto the module/class when
     # FeatureToggleRegistryManager is included.
     module ClassMethods
-      def features(&block)
+      def release(&block)
         release_toggle_registry.expand(&block) if block
         release_toggle_registry
       end

--- a/spec/togls/feature_toggle_registry_manager_spec.rb
+++ b/spec/togls/feature_toggle_registry_manager_spec.rb
@@ -7,23 +7,23 @@ describe Togls::FeatureToggleRegistryManager do
     context "when features have NOT been defined" do
       it "creates a new empty release toggle registry" do
         expect(Togls::ReleaseToggleRegistry).to receive(:new)
-        klass.features
+        klass.release
       end
     end
 
     context "when given a block" do
       it "expands the feature registry with a new block" do
-        registry = klass.features
+        registry = klass.release
         b = Proc.new {}
         expect(registry).to receive(:expand).and_yield(&b)
-        klass.features(&b)
+        klass.release(&b)
       end
     end
 
     it "returns the release toggle registry" do
       release_toggle_registry = double('release toggle registry')
       allow(Togls::ReleaseToggleRegistry).to receive(:new).and_return(release_toggle_registry)
-      expect(klass.features).to eq(release_toggle_registry)
+      expect(klass.release).to eq(release_toggle_registry)
     end
   end
 

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe "Togl" do
-  describe "defining feature toggles" do
+  describe "defining release toggles" do
     it "creates a new feature toggled on" do
-      Togls.features do
+      Togls.release do
         feature(:test, "some human readable description").on
       end
 
@@ -11,7 +11,7 @@ describe "Togl" do
     end
 
     it "creates a new feature toggled off" do
-      Togls.features do
+      Togls.release do
         feature(:test, "some human readable description").off
       end
 
@@ -19,7 +19,7 @@ describe "Togl" do
     end
 
     it "creates a new feature with a rule" do
-      Togls.features do
+      Togls.release do
         rule = Togls::Rules::Boolean.new(false)
         feature(:test, "some human readable description").on(rule)
       end
@@ -28,7 +28,7 @@ describe "Togl" do
     end
 
     it "creates a new feature with a group" do
-      Togls.features do
+      Togls.release do
         rule = Togls::Rules::Group.new(["someone"])
         feature(:test, "some human readable description").on(rule)
       end
@@ -40,11 +40,11 @@ describe "Togl" do
 
   describe "expanding feature toggles" do
     it "creates a new feature toggled on while keeping the previously defined features" do
-      Togls.features do
+      Togls.release do
         feature(:test, "some human readable description").on
       end
 
-      Togls.features do
+      Togls.release do
         feature(:bar, "some fooo").on
       end
 
@@ -56,7 +56,7 @@ describe "Togl" do
   describe "set the feature toggle registry" do
     it "uses the specified feature toggle registry" do
       Togls.enable_test_mode
-      Togls.features do
+      Togls.release do
         feature(:foo, "some magic foo").on
       end
 
@@ -66,7 +66,7 @@ describe "Togl" do
 
   describe "evaluating feature toggles" do
     it "asks a feature if it is on" do
-      Togls.features do
+      Togls.release do
         feature(:test, "some human readable description").on
       end
 
@@ -74,7 +74,7 @@ describe "Togl" do
     end
 
     it "asks a feature if it is off" do
-      Togls.features do
+      Togls.release do
         feature(:test, "some human readable description").on
       end
 
@@ -83,7 +83,7 @@ describe "Togl" do
 
     it "defaults to false when a feature is not defined" do
       allow(Togls.logger).to receive(:warn)
-      Togls.features do
+      Togls.release do
         feature(:test, "some human readable description").on
       end
 
@@ -96,7 +96,7 @@ describe "Togl" do
       end
 
       it "feature reports being off" do
-        Togls.features do
+        Togls.release do
           feature(:test, "some human readable description").on
         end
 
@@ -112,7 +112,7 @@ describe "Togl" do
       end
 
       it "feature reports being on" do
-        Togls.features do
+        Togls.release do
           feature(:test, "some human readable description").off
         end
 
@@ -128,7 +128,7 @@ describe "Togl" do
       end
 
       it "feature falls back to in memory store value" do
-        Togls.features do
+        Togls.release do
           feature(:test, "some human readable description").on
         end
 
@@ -154,7 +154,7 @@ describe "Togl" do
 
   describe "reviewing feature toggle" do
     it "outputs all the features" do
-      Togls.features do
+      Togls.release do
         feature(:test1, "test1 readable description").on
         feature(:test2, "test2 readable description").off
         feature(:test3, "test3 readable description")
@@ -174,7 +174,7 @@ off - test3 - test3 readable description
 
   describe "defining feature toggles in additional registry" do
     it "creates an isolated registred with a feature toggled off" do
-      Togls.features do
+      Togls.release do
         feature(:test, "some human readable description").on
       end
 
@@ -182,7 +182,7 @@ off - test3 - test3 readable description
         include Togls::FeatureToggleRegistryManager
       end
 
-      klass.features do
+      klass.release do
         feature(:test, "some human readable description").off
       end
 


### PR DESCRIPTION
Why you made the change:

I did this to better communicate the intent and associated registry that
is used by that DSL interface. It also opens us up to theoretically
adding support for other classifications of toggles in the future.

This relates to issue #38 .