### PR TITLE
Add `test_mode` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Added: `test_mode` block style method
 * Changed: `Togls.features` to `Togls.release`
 * Changed: Renamed `FeatureToggleRegistry` to `ReleaseToggleRegistry`
 * Added: `FeatureToggleRegistryManager` methods, `enable_test_mode` &

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -35,6 +35,12 @@ module Togls
         @release_toggle_registry = @previous_release_toggle_registry
       end
 
+      def test_mode
+        enable_test_mode
+        yield
+        disable_test_mode
+      end
+
       private
 
       def test_toggle_registry

--- a/spec/togls/feature_toggle_registry_manager_spec.rb
+++ b/spec/togls/feature_toggle_registry_manager_spec.rb
@@ -80,4 +80,24 @@ describe Togls::FeatureToggleRegistryManager do
         eq(test_registry)
     end
   end
+
+  describe '.test_mode' do
+    it 'enables test mode' do
+      allow(klass).to receive(:disable_test_mode)
+      expect(klass).to receive(:enable_test_mode)
+      klass.test_mode {}
+    end
+
+    it 'yields the provided block' do
+      allow(klass).to receive(:enable_test_mode)
+      allow(klass).to receive(:disable_test_mode)
+      expect { |b| klass.test_mode(&b) }.to yield_control
+    end
+
+    it 'disables test mode' do
+      allow(klass).to receive(:enable_test_mode)
+      expect(klass).to receive(:disable_test_mode)
+      klass.test_mode {}
+    end
+  end
 end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -64,6 +64,25 @@ describe "Togl" do
     end
   end
 
+  describe 'isolating toggles using test mode' do
+    it 'stores, isolates, and recovers the toggles' do
+      Togls.features do
+        feature(:foo, 'some foo feature').on
+      end
+
+      Togls.test_mode do
+        Togls.features do
+          feature(:zar, 'some zar feature').on
+        end
+
+        expect(Togls.feature(:foo).on?).to eq(false)
+        expect(Togls.feature(:zar).on?).to eq(true)
+      end
+
+      expect(Togls.feature(:foo).on?).to eq(true)
+    end
+  end
+
   describe "evaluating feature toggles" do
     it "asks a feature if it is on" do
       Togls.release do

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -66,12 +66,12 @@ describe "Togl" do
 
   describe 'isolating toggles using test mode' do
     it 'stores, isolates, and recovers the toggles' do
-      Togls.features do
+      Togls.release do
         feature(:foo, 'some foo feature').on
       end
 
       Togls.test_mode do
-        Togls.features do
+        Togls.release do
           feature(:zar, 'some zar feature').on
         end
 


### PR DESCRIPTION
Why you made the change:

I did this so that there would be a convenient way to manage enabling
and disabling test mode for you when you can use a block.

Relates to issue #44 .