### PR TITLE
Remove togls:features rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Romeved: `features` rake task
 * Added: `test_mode` block style method
 * Changed: `Togls.features` to `Togls.release`
 * Changed: Renamed `FeatureToggleRegistry` to `ReleaseToggleRegistry`

--- a/lib/tasks/togls.rake
+++ b/lib/tasks/togls.rake
@@ -1,9 +1,0 @@
-namespace :togls do
-  desc 'Output all features including status (on, off, ? - unknown due to' \
-   ' complex rule), key, description'
-  task :features do
-    Togls.release.all.each do |toggle|
-      puts toggle.to_s
-    end
-  end
-end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -171,26 +171,6 @@ describe "Togl" do
     end
   end
 
-  describe "reviewing feature toggle" do
-    it "outputs all the features" do
-      Togls.release do
-        feature(:test1, "test1 readable description").on
-        feature(:test2, "test2 readable description").off
-        feature(:test3, "test3 readable description")
-        feature(:test4, "test4 readable description").on(Togls::Rules::Boolean.new(true))
-      end
-
-      require 'rake'
-      load 'lib/tasks/togls.rake'
-
-      expect { Rake::Task["togls:features"].invoke }.to output(%q{ on - test1 - test1 readable description
-off - test2 - test2 readable description
-off - test3 - test3 readable description
- on - test4 - test4 readable description
-}).to_stdout
-    end
-  end
-
   describe "defining feature toggles in additional registry" do
     it "creates an isolated registred with a feature toggled off" do
       Togls.release do


### PR DESCRIPTION
Why you made the change:

I did this because this feature turned out to not be that valuable and
we don't want to have to pay the maintenance cost of keeping it around.