### PR TITLE
Add an exception for when a feature has already been defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ that you can set version constraints properly.
 * `Changed`: `ReleaseToggleRegistryManager` to `FeatureToggleRegistryManager`
 * `Added`: Base Error class for Togls exceptions
   ([#39](https://github.com/codebreakdown/togls/issues/39))
+* `Added`: Exception for when a feature has already been defined in the feature
+  repository
+  ([#42](https://github.com/codebreakdown/togls/issues/42))
 
 #### [v2.2.1] - 2016-03-24
 

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -4,4 +4,5 @@ module Togls
   class MissingDriver < Error; end
   class InvalidDriver < Error; end
   class NotImplemented < Error; end
+  class FeatureAlreadyDefined < Error; end
 end

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -34,7 +34,7 @@ module Togls
       feature_data
     end
 
-    def exist?(feature_id)
+    def include?(feature_id)
       result = fetch_feature_data(feature_id)
       result.nil? ? false : true
     end

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -34,6 +34,11 @@ module Togls
       feature_data
     end
 
+    def exist?(feature_id)
+      result = fetch_feature_data(feature_id)
+      result.nil? ? false : true
+    end
+
     def get(feature_id)
       feature_data = fetch_feature_data(feature_id)
       reconstitute_feature(feature_data)

--- a/lib/togls/release_toggle_registry.rb
+++ b/lib/togls/release_toggle_registry.rb
@@ -34,7 +34,7 @@ module Togls
     end
 
     def verify_uniqueness_of_feature(key)
-      if @feature_repository.exist?(key.to_s)
+      if @feature_repository.include?(key.to_s)
         raise FeatureAlreadyDefined, "Feature identified by '#{key}' has already been defined"
       end
     end

--- a/lib/togls/release_toggle_registry.rb
+++ b/lib/togls/release_toggle_registry.rb
@@ -7,6 +7,7 @@ module Togls
   # entities. This plays a significant portion in the primary DSL as well.
   class ReleaseToggleRegistry
     def initialize(feature_repository)
+      @feature_repository = feature_repository
       @toggle_repository_drivers = [
         Togls::ToggleRepositoryDrivers::InMemoryDriver.new,
         Togls::ToggleRepositoryDrivers::EnvOverrideDriver.new]
@@ -14,7 +15,7 @@ module Togls
         [Togls::RuleRepositoryDrivers::InMemoryDriver.new]
       @rule_repository = Togls::RuleRepository.new(@rule_repository_drivers)
       @toggle_repository = Togls::ToggleRepository.new(
-        @toggle_repository_drivers, feature_repository, @rule_repository)
+        @toggle_repository_drivers, @feature_repository, @rule_repository)
       @rule_repository.store(Togls::Rules::Boolean.new(true))
       @rule_repository.store(Togls::Rules::Boolean.new(false))
     end
@@ -25,10 +26,17 @@ module Togls
     end
 
     def feature(key, desc)
+      verify_uniqueness_of_feature(key)
       feature = Togls::Feature.new(key, desc)
       toggle = Togls::Toggle.new(feature)
       @toggle_repository.store(toggle)
       Togls::Toggler.new(@toggle_repository, toggle)
+    end
+
+    def verify_uniqueness_of_feature(key)
+      if @feature_repository.exist?(key.to_s)
+        raise FeatureAlreadyDefined, "Feature identified by '#{key}' has already been defined"
+      end
     end
 
     def get(key)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,6 @@ require 'pry'
 RSpec.configure do |c|
   c.before(:each) do
     Togls.instance_variable_set(:@release_toggle_registry, nil)
+    Togls.instance_variable_set(:@feature_repository, nil)
   end
 end

--- a/spec/togls/feature_repository_spec.rb
+++ b/spec/togls/feature_repository_spec.rb
@@ -132,6 +132,27 @@ describe Togls::FeatureRepository do
     end
   end
 
+  describe "#exist?" do
+    it "fetches the feature data from the drivers" do
+      expect(subject).to receive(:fetch_feature_data).with("some_id")
+      subject.exist?("some_id")
+    end
+
+    context "when feature data is fetched" do
+      it "returns true" do
+        allow(subject).to receive(:fetch_feature_data).and_return({ "some": "data" })
+        expect(subject.exist?("some_id")).to be_truthy
+      end
+    end
+
+    context "when feature data can't be found" do
+      it "returns false" do
+        allow(subject).to receive(:fetch_feature_data).and_return(nil)
+        expect(subject.exist?("some_id")).to be_falsey
+      end
+    end
+  end
+
   describe "#get" do
     it "get the feature data" do
       allow(subject).to receive(:reconstitute_feature)

--- a/spec/togls/feature_repository_spec.rb
+++ b/spec/togls/feature_repository_spec.rb
@@ -132,23 +132,23 @@ describe Togls::FeatureRepository do
     end
   end
 
-  describe "#exist?" do
+  describe "#include?" do
     it "fetches the feature data from the drivers" do
       expect(subject).to receive(:fetch_feature_data).with("some_id")
-      subject.exist?("some_id")
+      subject.include?("some_id")
     end
 
     context "when feature data is fetched" do
       it "returns true" do
         allow(subject).to receive(:fetch_feature_data).and_return({ "some": "data" })
-        expect(subject.exist?("some_id")).to be_truthy
+        expect(subject.include?("some_id")).to be_truthy
       end
     end
 
     context "when feature data can't be found" do
       it "returns false" do
         allow(subject).to receive(:fetch_feature_data).and_return(nil)
-        expect(subject.exist?("some_id")).to be_falsey
+        expect(subject.include?("some_id")).to be_falsey
       end
     end
   end

--- a/spec/togls/release_toggle_registry_spec.rb
+++ b/spec/togls/release_toggle_registry_spec.rb
@@ -192,7 +192,7 @@ describe Togls::ReleaseToggleRegistry do
   describe "#verify_uniqueness_of_feature" do
     context "when the feature exists" do
       it "raises a feature has already been defined error" do
-        allow(feature_repository).to receive(:exist?).and_return true
+        allow(feature_repository).to receive(:include?).and_return true
         expect { subject.verify_uniqueness_of_feature(:some_key) }
           .to raise_error Togls::FeatureAlreadyDefined, "Feature identified by 'some_key' has already been defined"
       end
@@ -200,7 +200,7 @@ describe Togls::ReleaseToggleRegistry do
 
     context "when the feature doesn't exist" do
       it "does NOT raise a exception" do
-        allow(feature_repository).to receive(:exist?).and_return false
+        allow(feature_repository).to receive(:include?).and_return false
         expect { subject.verify_uniqueness_of_feature(:some_key) }.not_to raise_error
       end
     end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -36,6 +36,21 @@ describe "Togl" do
       expect(Togls.feature(:test).on?("someone")).to eq(true)
       expect(Togls.feature(:test).on?("someone_else")).to eq(false)
     end
+
+    context 'when redefining an existing feature' do
+      it 'raises an already defined error' do
+        Togls.release do
+          feature(:foo, 'some decription')
+        end
+
+        expect {
+          Togls.release do
+            puts 'defining again'
+            feature(:foo, 'previously defined')
+          end
+        }.to raise_error Togls::FeatureAlreadyDefined
+      end
+    end
   end
 
   describe "expanding feature toggles" do

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -45,7 +45,6 @@ describe "Togl" do
 
         expect {
           Togls.release do
-            puts 'defining again'
             feature(:foo, 'previously defined')
           end
         }.to raise_error Togls::FeatureAlreadyDefined


### PR DESCRIPTION
I did this because we don't want the state of release feature toggles to be
defined multiple times. This could cause developers to create toggles that they
think to be unique to their needs but in actuality could be turning a previously
defined feature on or off erroneously.