### PR TITLE
Add meta data storage to rule type repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Changed`: rule type repository to store meta data
+  ([#62](https://github.com/codebreakdown/togls/issues/62))
 * `Added`: uniqueness check for rule types
   ([#61](https://github.com/codebreakdown/togls/issues/61)
 * `Changed`: rule repository to use rule type repository

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -14,6 +14,10 @@ module Togls
       raise Togls::NotImplemented, "Rule type description not implemented"
     end
 
+    def self.target_type
+      :any
+    end
+
     def initialize(data = nil)
       @data = data
     end

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -6,6 +6,14 @@ module Togls
   class Rule
     attr_reader :data
 
+    def self.title
+      raise Togls::NotImplemented, "Rule type title not implemented"
+    end
+
+    def self.description
+      raise Togls::NotImplemented, "Rule type description not implemented"
+    end
+
     def initialize(data = nil)
       @data = data
     end

--- a/lib/togls/rule_type_repository.rb
+++ b/lib/togls/rule_type_repository.rb
@@ -6,7 +6,7 @@ module Togls
 
     def store(type_id, klass)
       @drivers.each do |driver|
-        driver.store(type_id.to_s, klass.to_s)
+        driver.store(type_id.to_s, klass.to_s, klass.title, klass.description)
       end
     end
 

--- a/lib/togls/rule_type_repository.rb
+++ b/lib/togls/rule_type_repository.rb
@@ -6,7 +6,8 @@ module Togls
 
     def store(type_id, klass)
       @drivers.each do |driver|
-        driver.store(type_id.to_s, klass.to_s, klass.title, klass.description)
+        driver.store(type_id.to_s, klass.to_s, klass.title, klass.description,
+                     klass.target_type.to_s)
       end
     end
 

--- a/lib/togls/rule_type_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/rule_type_repository_drivers/in_memory_driver.rb
@@ -3,13 +3,17 @@ module Togls
     class InMemoryDriver
       def initialize
         @rule_types = {}
+        @rule_type_meta_data = {}
         @type_ids = {}
         @rule_types_lock = Mutex.new
       end
 
-      def store(type_id, klass_str, title, description)
+      def store(type_id, klass_str, title, description, target_type)
         @rule_types_lock.synchronize do
           @rule_types[type_id] = klass_str
+          @rule_type_meta_data[type_id] = { title: title,
+                                            description: description,
+                                            target_type: target_type }
           @type_ids[klass_str] = type_id
         end
       end
@@ -17,7 +21,17 @@ module Togls
       def get_klass(type_id)
         @rule_types_lock.synchronize do
           if @rule_types.has_key?(type_id)
-            @rule_types[type_id]
+            @rule_types[type_id].dup
+          else
+            nil
+          end
+        end
+      end
+
+      def get_type_meta_data(type_id)
+        @rule_types_lock.synchronize do
+          if @rule_types.has_key?(type_id)
+            @rule_type_meta_data[type_id].dup
           else
             nil
           end
@@ -27,7 +41,7 @@ module Togls
       def get_type_id(klass_str)
         @rule_types_lock.synchronize do
           if @type_ids.has_key?(klass_str)
-            @type_ids[klass_str]
+            @type_ids[klass_str].dup
           else
             nil
           end

--- a/lib/togls/rule_type_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/rule_type_repository_drivers/in_memory_driver.rb
@@ -7,7 +7,7 @@ module Togls
         @rule_types_lock = Mutex.new
       end
 
-      def store(type_id, klass_str)
+      def store(type_id, klass_str, title, description)
         @rule_types_lock.synchronize do
           @rule_types[type_id] = klass_str
           @type_ids[klass_str] = type_id

--- a/lib/togls/rules/boolean.rb
+++ b/lib/togls/rules/boolean.rb
@@ -15,6 +15,22 @@ module Togls
     #   ...
     # end
     class Boolean < Rule
+      def self.title
+        "Boolean"
+      end
+
+      def self.description
+        %Q{
+The Boolean rule type is the base line rule for Togls. It allows you to
+flag a feature on/off by specifing a boolean value as the initialization
+data. For example:
+
+Togls::Rules::Boolean.new(true) # rule that always evaluates to on
+
+Togls::Rules::Boolean.new(false) # rule that always evaluates to false
+        }
+      end
+
       def run(_key, _target = nil)
         @data
       end

--- a/lib/togls/rules/boolean.rb
+++ b/lib/togls/rules/boolean.rb
@@ -27,7 +27,7 @@ data. For example:
 
 Togls::Rules::Boolean.new(true) # rule that always evaluates to on
 
-Togls::Rules::Boolean.new(false) # rule that always evaluates to false
+Togls::Rules::Boolean.new(false) # rule that always evaluates to off
         }
       end
 

--- a/lib/togls/rules/group.rb
+++ b/lib/togls/rules/group.rb
@@ -28,7 +28,7 @@ works is that you specify the initialization data as the array of
 identifiers inclusively included in the group. Then when the feature
 toggle is evaluated you would pass the target and if that target exists
 in the inclusive list then it would evaluate to on. If not, it would
-evaluate to false. Examples:
+evaluate to off. Examples:
 
 # Group defined by user ids
 alpha_testers = Togls::Rules::Group.new([23, 343, 222, 123])

--- a/lib/togls/rules/group.rb
+++ b/lib/togls/rules/group.rb
@@ -23,18 +23,23 @@ module Togls
 
       def self.description
         %Q{
-The Group rule type allows you to define arbitrary groups. The way it
-works is that you specify the initialization data as the array of
-identifiers inclusively included in the group. Then when the feature
-toggle is evaluated you would pass the target and if that target exists
-in the inclusive list then it would evaluate to on. If not, it would
-evaluate to off. Examples:
+The Group rule allows you to define an arbitrary collection of objects to be
+used in evaluating against the target. Specify the initialization data as an
+array of inclusive identifiers for the group. When the feature toggle is
+evaluated if the passed in target is included in the group then it is evaluated
+to on. If not, it evaluates to off. Examples:
 
 # Group defined by user ids
 alpha_testers = Togls::Rules::Group.new([23, 343, 222, 123])
 
 # Group defined by email addresses
 beta_testers = Togls::Rules::Group.new(['bob@example.com', 'cindy@example.com'])
+
+Togls.release do
+  feature(:foo, 'some foo desc').on(beta_testers)
+end
+
+Togls.feature(:foo).on?('jack@example.com') # evalutes to false (a.k.a. off)
         }
       end
 

--- a/lib/togls/rules/group.rb
+++ b/lib/togls/rules/group.rb
@@ -17,6 +17,27 @@ module Togls
     #   ...
     # end
     class Group < Rule
+      def self.title
+        "Group"
+      end
+
+      def self.description
+        %Q{
+The Group rule type allows you to define arbitrary groups. The way it
+works is that you specify the initialization data as the array of
+identifiers inclusively included in the group. Then when the feature
+toggle is evaluated you would pass the target and if that target exists
+in the inclusive list then it would evaluate to on. If not, it would
+evaluate to false. Examples:
+
+# Group defined by user ids
+alpha_testers = Togls::Rules::Group.new([23, 343, 222, 123])
+
+# Group defined by email addresses
+beta_testers = Togls::Rules::Group.new(['bob@example.com', 'cindy@example.com'])
+        }
+      end
+
       def run(_key, target)
         @data.include?(target)
       end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe Togls::Rule do
+  describe '.title' do
+    it 'raises NotImplemented exception' do
+      klass = Class.new(Togls::Rule)
+      expect { klass.title }.to raise_error(Togls::NotImplemented)
+    end
+  end
+
+  describe '.description' do
+    it 'raises NotImplemented exception' do
+      klass = Class.new(Togls::Rule)
+      expect { klass.description }.to raise_error(Togls::NotImplemented)
+    end
+  end
+
   describe "#initialize" do
     it "assigns the given data to an instance variable" do
       data = double('data')

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -15,6 +15,13 @@ describe Togls::Rule do
     end
   end
 
+  describe '.target_type' do
+    it 'returns the default of :any' do
+      klass = Class.new(Togls::Rule)
+      expect(klass.target_type).to eq(:any)
+    end
+  end
+
   describe "#initialize" do
     it "assigns the given data to an instance variable" do
       data = double('data')

--- a/spec/togls/rule_type_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/rule_type_repository_drivers/in_memory_driver_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Togls::RuleTypeRepositoryDrivers::InMemoryDriver do
   describe 'storing and retrieving' do
     it 'saves the storage payload and retrieves the klass and type_id' do
       klass = Class.new
-      subject.store('some_key', klass.to_s)
+      subject.store('some_key', klass.to_s, 'some-title', 'some-desc')
       expect(subject.get_klass('some_key')).to eq(klass.to_s)
       expect(subject.get_type_id(klass.to_s)).to eq('some_key')
     end

--- a/spec/togls/rule_type_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/rule_type_repository_drivers/in_memory_driver_spec.rb
@@ -24,8 +24,11 @@ RSpec.describe Togls::RuleTypeRepositoryDrivers::InMemoryDriver do
   describe 'storing and retrieving' do
     it 'saves the storage payload and retrieves the klass and type_id' do
       klass = Class.new
-      subject.store('some_key', klass.to_s, 'some-title', 'some-desc')
+      subject.store('some_key', klass.to_s, 'some-title', 'some-desc', 'some-target-type')
       expect(subject.get_klass('some_key')).to eq(klass.to_s)
+      expect(subject.get_type_meta_data('some_key')).to eq({ title: 'some-title',
+                                                             description: 'some-desc',
+                                                             target_type: 'some-target-type' })
       expect(subject.get_type_id(klass.to_s)).to eq('some_key')
     end
 

--- a/spec/togls/rule_type_repository_spec.rb
+++ b/spec/togls/rule_type_repository_spec.rb
@@ -26,11 +26,13 @@ RSpec.describe Togls::RuleTypeRepository do
   describe '#store' do
     it 'stores the given key and klass in the drivers' do
       klass = double('some rule class', title: 'some-title',
-                     description: 'some-desc')
+                     description: 'some-desc', target_type: :foo_target_type)
       expect(driver_one).to receive(:store).with('some_key', klass.to_s,
-                                                anything, anything)
+                                                 'some-title', 'some-desc',
+                                                 'foo_target_type')
       expect(driver_two).to receive(:store).with('some_key', klass.to_s,
-                                                anything, anything)
+                                                 'some-title', 'some-desc',
+                                                 'foo_target_type')
       subject.store('some_key', klass)
     end
   end

--- a/spec/togls/rule_type_repository_spec.rb
+++ b/spec/togls/rule_type_repository_spec.rb
@@ -25,9 +25,12 @@ RSpec.describe Togls::RuleTypeRepository do
 
   describe '#store' do
     it 'stores the given key and klass in the drivers' do
-      klass = double('some rule class')
-      expect(driver_one).to receive(:store).with('some_key', klass.to_s)
-      expect(driver_two).to receive(:store).with('some_key', klass.to_s)
+      klass = double('some rule class', title: 'some-title',
+                     description: 'some-desc')
+      expect(driver_one).to receive(:store).with('some_key', klass.to_s,
+                                                anything, anything)
+      expect(driver_two).to receive(:store).with('some_key', klass.to_s,
+                                                anything, anything)
       subject.store('some_key', klass)
     end
   end

--- a/spec/togls/rules/boolean_spec.rb
+++ b/spec/togls/rules/boolean_spec.rb
@@ -13,6 +13,12 @@ describe Togls::Rules::Boolean do
     end
   end
 
+  describe '.target_type' do
+    it 'returns :any' do
+      expect(Togls::Rules::Boolean.target_type).to eq(:any)
+    end
+  end
+
   describe "#run" do
     it "returns the provided boolean value" do
       bool_rule = Togls::Rules::Boolean.new(true)

--- a/spec/togls/rules/boolean_spec.rb
+++ b/spec/togls/rules/boolean_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 describe Togls::Rules::Boolean do
+  describe '.title' do
+    it 'does not raise an error' do
+      Togls::Rules::Boolean.title
+    end
+  end
+
+  describe '.description' do
+    it 'does not raise an error' do
+      Togls::Rules::Boolean.description
+    end
+  end
+
   describe "#run" do
     it "returns the provided boolean value" do
       bool_rule = Togls::Rules::Boolean.new(true)

--- a/spec/togls/rules/group_spec.rb
+++ b/spec/togls/rules/group_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 describe Togls::Rules::Group do
+  describe '.title' do
+    it 'does not raise an error' do
+      Togls::Rules::Boolean.title
+    end
+  end
+
+  describe '.description' do
+    it 'does not raise an error' do
+      Togls::Rules::Boolean.description
+    end
+  end
+
   describe "#run" do
     context "when the target is included in the list" do
       it "returns true" do

--- a/spec/togls/rules/group_spec.rb
+++ b/spec/togls/rules/group_spec.rb
@@ -3,13 +3,19 @@ require 'spec_helper'
 describe Togls::Rules::Group do
   describe '.title' do
     it 'does not raise an error' do
-      Togls::Rules::Boolean.title
+      Togls::Rules::Group.title
     end
   end
 
   describe '.description' do
     it 'does not raise an error' do
-      Togls::Rules::Boolean.description
+      Togls::Rules::Group.description
+    end
+  end
+
+  describe '.target_type' do
+    it 'returns :any' do
+      expect(Togls::Rules::Group.target_type).to eq(:any)
     end
   end
 

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -13,24 +13,42 @@ describe "Togl" do
       end
 
       Togls.rule_types do
-        register(:some_rule_type, Class.new)
+        register(:some_rule_type, rule_klass)
       end
     end
   end
 
   describe 'get registered rule type class' do
     it 'returns the associated rule type class' do
-      Togls.rule_types do
-        register(:test_rule_one, String)
+      FooBarRule = Class.new(Togls::Rule)
+      def FooBarRule.title
+        'some title'
       end
 
-      expect(Togls.rule_type(:test_rule_one)).to eq(String)
+      def FooBarRule.description
+        'some desc'
+      end
+
+      Togls.rule_types do
+        register(:test_rule_one, FooBarRule)
+      end
+
+      expect(Togls.rule_type(:test_rule_one)).to eq(FooBarRule)
     end
 
     context 'when registering the same rule type' do
       it 'raises an rule type uniqueness error' do
+        FooBarRule = Class.new(Togls::Rule)
+        def FooBarRule.title
+          'some title'
+        end
+
+        def FooBarRule.description
+          'some desc'
+        end
+
         Togls.rule_types do
-          register(:test_rule, String)
+          register(:test_rule, FooBarRule)
         end
 
         expect {
@@ -43,15 +61,24 @@ describe "Togl" do
 
     context 'when the rule class has already been used in a type' do
       it 'raises an uniqueness error' do
+        FooBarRule = Class.new(Togls::Rule)
+        def FooBarRule.title
+          'some title'
+        end
+
+        def FooBarRule.description
+          'some desc'
+        end
+
         Togls.rule_types do
-          register(:rule_id, String)
+          register(:rule_id, FooBarRule)
         end
 
         expect {
           Togls.rule_types do
-            register('different_id', String)
+            register('different_id', FooBarRule)
           end
-        }.to raise_error Togls::RuleTypeAlreadyDefined, "Rule Type with class 'String' has already been registered"
+        }.to raise_error Togls::RuleTypeAlreadyDefined, "Rule Type with class 'FooBarRule' has already been registered"
       end
     end
   end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -3,6 +3,15 @@ require 'spec_helper'
 describe "Togl" do
   describe 'registering rule types' do
     it 'registers the rule type' do
+      rule_klass = Class.new(Togls::Rule)
+      def rule_klass.title
+        'some title'
+      end
+
+      def rule_klass.description
+        'some desc'
+      end
+
       Togls.rule_types do
         register(:some_rule_type, Class.new)
       end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 describe "Togl" do
   describe 'registering rule types' do
     it 'registers the rule type' do
-      rule_klass = Class.new(Togls::Rule)
-      def rule_klass.title
-        'some title'
-      end
+      rule_klass = Class.new(Togls::Rule) do
+        def self.title
+          'some title'
+        end
 
-      def rule_klass.description
-        'some desc'
+        def self.description
+          'some desc'
+        end
       end
 
       Togls.rule_types do
@@ -20,13 +21,14 @@ describe "Togl" do
 
   describe 'get registered rule type class' do
     it 'returns the associated rule type class' do
-      FooBarRule = Class.new(Togls::Rule)
-      def FooBarRule.title
-        'some title'
-      end
+      FooBarRule = Class.new(Togls::Rule) do
+        def self.title
+          'some title'
+        end
 
-      def FooBarRule.description
-        'some desc'
+        def self.description
+          'some desc'
+        end
       end
 
       Togls.rule_types do
@@ -38,13 +40,14 @@ describe "Togl" do
 
     context 'when registering the same rule type' do
       it 'raises an rule type uniqueness error' do
-        FooBarRule = Class.new(Togls::Rule)
-        def FooBarRule.title
-          'some title'
-        end
+        FooBarRule = Class.new(Togls::Rule) do
+          def self.title
+            'some title'
+          end
 
-        def FooBarRule.description
-          'some desc'
+          def self.description
+            'some desc'
+          end
         end
 
         Togls.rule_types do
@@ -61,13 +64,14 @@ describe "Togl" do
 
     context 'when the rule class has already been used in a type' do
       it 'raises an uniqueness error' do
-        FooBarRule = Class.new(Togls::Rule)
-        def FooBarRule.title
-          'some title'
-        end
+        FooBarRule = Class.new(Togls::Rule) do
+          def self.title
+            'some title'
+          end
 
-        def FooBarRule.description
-          'some desc'
+          def self.description
+            'some desc'
+          end
         end
 
         Togls.rule_types do


### PR DESCRIPTION
Why you made the change:

I did this so that the rule type meta data (title, description) would
now be stored via the rule type repository.

This relates to issue #62 