### PR TITLE
Add target type to feature definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Added`: optional target types, and target type checking
+  ([#65](https://github.com/codebreakdown/togls/issues/65))
 * `Changed`: rule type repository to store meta data
   ([#62](https://github.com/codebreakdown/togls/issues/62))
 * `Added`: uniqueness check for rule types

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -1,6 +1,7 @@
 require 'togls/version'
 require 'togls/errors'
 require 'togls/helpers'
+require 'togls/target_types'
 require 'togls/toggle_repository_drivers'
 require 'togls/toggle_repository_drivers/in_memory_driver'
 require 'togls/toggle_repository_drivers/env_override_driver'

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -6,5 +6,5 @@ module Togls
   class NotImplemented < Error; end
   class FeatureAlreadyDefined < Error; end
   class RuleTypeAlreadyDefined < Error; end
-  class RuleFeatureTargetTypeMissMatch < Error; end
+  class RuleFeatureTargetTypeMismatch < Error; end
 end

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -6,4 +6,5 @@ module Togls
   class NotImplemented < Error; end
   class FeatureAlreadyDefined < Error; end
   class RuleTypeAlreadyDefined < Error; end
+  class RuleFeatureTargetTypeMissMatch < Error; end
 end

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -6,7 +6,7 @@ module Togls
   class Feature
     attr_reader :key, :description, :target_type
 
-    def initialize(key, description, target_type = :any)
+    def initialize(key, description, target_type = Togls::TargetTypes::ANY)
       @key = key.to_s
       @description = description
       @target_type = target_type

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -4,11 +4,12 @@ module Togls
   # The Feature model is the business representation of a feature. It is how
   # Togls primarily interfaces with the concept of a feature.
   class Feature
-    attr_reader :key, :description
+    attr_reader :key, :description, :target_type
 
-    def initialize(key, description)
+    def initialize(key, description, target_type = :any)
       @key = key.to_s
       @description = description
+      @target_type = target_type
     end
 
     def id

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -22,7 +22,7 @@ module Togls
     end
 
     def extract_feature_data(feature)
-      { 'key' => feature.key, 'description' => feature.description }
+      { 'key' => feature.key, 'description' => feature.description, 'target_type' => feature.target_type.to_s }
     end
 
     def fetch_feature_data(id)
@@ -45,8 +45,14 @@ module Togls
     end
 
     def reconstitute_feature(feature_data)
-      Togls::Feature.new(feature_data['key'],
-                         feature_data['description'])
+      if feature_data['target_type'].nil?
+        Togls::Feature.new(feature_data['key'],
+                           feature_data['description'])
+      else
+        Togls::Feature.new(feature_data['key'],
+                           feature_data['description'],
+                           feature_data['target_type'].to_sym)
+      end
     end
   end
 end

--- a/lib/togls/null_toggle.rb
+++ b/lib/togls/null_toggle.rb
@@ -17,4 +17,7 @@ module Togls
       self
     end
   end
+
+  class ToggleMissingToggle < NullToggle; end
+  class RuleFeatureMissMatchToggle < NullToggle; end
 end

--- a/lib/togls/null_toggle.rb
+++ b/lib/togls/null_toggle.rb
@@ -19,5 +19,5 @@ module Togls
   end
 
   class ToggleMissingToggle < NullToggle; end
-  class RuleFeatureMissMatchToggle < NullToggle; end
+  class RuleFeatureMismatchToggle < NullToggle; end
 end

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -15,7 +15,7 @@ module Togls
     end
 
     def self.target_type
-      :any
+      Togls::TargetTypes::ANY
     end
 
     def initialize(data = nil)

--- a/lib/togls/target_types.rb
+++ b/lib/togls/target_types.rb
@@ -1,0 +1,5 @@
+module Togls
+  module TargetTypes
+    ANY = :any
+  end
+end

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -17,7 +17,7 @@ module Togls
     end
 
     def rule=(rule)
-      raise Togls::RuleFeatureTargetTypeMissMatch unless target_matches?(rule)
+      raise Togls::RuleFeatureTargetTypeMismatch unless target_matches?(rule)
       @rule = rule
     end
 

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -5,8 +5,7 @@ module Togls
   # responsibility is binding a specific rule to a specific feature. Toggle's by
   # default are associated with a boolean rule initialized to false.
   class Toggle
-    attr_reader :feature
-    attr_accessor :rule
+    attr_reader :feature, :rule
 
     def initialize(feature)
       @feature = feature
@@ -15,6 +14,16 @@ module Togls
 
     def id
       @feature.id
+    end
+
+    def rule=(rule)
+      raise Togls::RuleFeatureTargetTypeMissMatch unless target_matches?(rule)
+      @rule = rule
+    end
+
+    def target_matches?(rule)
+      @feature.target_type == rule.class.target_type ||
+        @feature.target_type == :any
     end
 
     def on?(target = nil)

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -21,9 +21,16 @@ module Togls
       @rule = rule
     end
 
+    # feature target type | rule target type | match?
+    # ------------------------------------------------
+    # any (aka none)      | any              | true
+    # something (foo)     | any              | true
+    # any (aka none)      | something (foo)  | false
+    # something (foo)     | something (foo)  | true
+    # something (foo)     | something (bar)  | false
     def target_matches?(rule)
       @feature.target_type == rule.class.target_type ||
-        @feature.target_type == Togls::TargetTypes::ANY
+        rule.class.target_type == Togls::TargetTypes::ANY
     end
 
     def on?(target = nil)

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -23,7 +23,7 @@ module Togls
 
     def target_matches?(rule)
       @feature.target_type == rule.class.target_type ||
-        @feature.target_type == :any
+        @feature.target_type == Togls::TargetTypes::ANY
     end
 
     def on?(target = nil)

--- a/lib/togls/toggle_registry.rb
+++ b/lib/togls/toggle_registry.rb
@@ -34,8 +34,6 @@ module Togls
       toggle = @toggle_repository.get(key.to_s)
       if toggle.is_a?(Togls::ToggleMissingToggle)
         Togls.logger.warn("Feature identified by '#{key}' has not been defined")
-      elsif toggle.is_a?(Togls::RuleFeatureMismatchToggle)
-        Togls.logger.warn("Feature identified by '#{key}' has a rule mismatch")
       end
       toggle
     end

--- a/lib/togls/toggle_registry.rb
+++ b/lib/togls/toggle_registry.rb
@@ -16,7 +16,7 @@ module Togls
       self
     end
 
-    def feature(key, desc, target_type: :any)
+    def feature(key, desc, target_type: Togls::TargetTypes::ANY)
       verify_uniqueness_of_feature(key)
       feature = Togls::Feature.new(key, desc, target_type)
       toggle = Togls::Toggle.new(feature)

--- a/lib/togls/toggle_registry.rb
+++ b/lib/togls/toggle_registry.rb
@@ -16,9 +16,9 @@ module Togls
       self
     end
 
-    def feature(key, desc)
+    def feature(key, desc, target_type: :any)
       verify_uniqueness_of_feature(key)
-      feature = Togls::Feature.new(key, desc)
+      feature = Togls::Feature.new(key, desc, target_type)
       toggle = Togls::Toggle.new(feature)
       @toggle_repository.store(toggle)
       Togls::Toggler.new(@toggle_repository, toggle)
@@ -32,8 +32,10 @@ module Togls
 
     def get(key)
       toggle = @toggle_repository.get(key.to_s)
-      if toggle.is_a?(Togls::NullToggle)
+      if toggle.is_a?(Togls::ToggleMissingToggle)
         Togls.logger.warn("Feature identified by '#{key}' has not been defined")
+      elsif toggle.is_a?(Togls::RuleFeatureMissMatchToggle)
+        Togls.logger.warn("Feature identified by '#{key}' has a rule miss-match")
       end
       toggle
     end

--- a/lib/togls/toggle_registry.rb
+++ b/lib/togls/toggle_registry.rb
@@ -35,7 +35,7 @@ module Togls
       if toggle.is_a?(Togls::ToggleMissingToggle)
         Togls.logger.warn("Feature identified by '#{key}' has not been defined")
       elsif toggle.is_a?(Togls::RuleFeatureMismatchToggle)
-        Togls.logger.warn("Feature identified by '#{key}' has a rule miss-match")
+        Togls.logger.warn("Feature identified by '#{key}' has a rule mismatch")
       end
       toggle
     end

--- a/lib/togls/toggle_registry.rb
+++ b/lib/togls/toggle_registry.rb
@@ -34,7 +34,7 @@ module Togls
       toggle = @toggle_repository.get(key.to_s)
       if toggle.is_a?(Togls::ToggleMissingToggle)
         Togls.logger.warn("Feature identified by '#{key}' has not been defined")
-      elsif toggle.is_a?(Togls::RuleFeatureMissMatchToggle)
+      elsif toggle.is_a?(Togls::RuleFeatureMismatchToggle)
         Togls.logger.warn("Feature identified by '#{key}' has a rule miss-match")
       end
       toggle

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -32,15 +32,19 @@ module Togls
     def get(id)
       toggle_data = fetch_toggle_data(id)
       return reconstitute_toggle(toggle_data) if toggle_data
-      Togls::NullToggle.new
+      Togls::ToggleMissingToggle.new
     end
 
     def reconstitute_toggle(toggle_data)
       feature = @feature_repository.get(toggle_data['feature_id'])
       rule = @rule_repository.get(toggle_data['rule_id'])
       toggle = Togls::Toggle.new(feature)
-      toggle.rule = rule
-      toggle
+      begin
+        toggle.rule = rule
+        toggle
+      rescue Togls::RuleFeatureTargetTypeMissMatch
+        return Togls::RuleFeatureMissMatchToggle.new
+      end
     end
 
     def fetch_toggle_data(id)

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -43,6 +43,7 @@ module Togls
         toggle.rule = rule
         toggle
       rescue Togls::RuleFeatureTargetTypeMismatch
+        Togls.logger.warn("Feature (#{feature.key}) with target type '#{feature.target_type}' has a rule (#{rule.id}) mismatch with target type '#{rule.class.target_type}'")
         return Togls::RuleFeatureMismatchToggle.new
       end
     end

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -42,8 +42,8 @@ module Togls
       begin
         toggle.rule = rule
         toggle
-      rescue Togls::RuleFeatureTargetTypeMissMatch
-        return Togls::RuleFeatureMissMatchToggle.new
+      rescue Togls::RuleFeatureTargetTypeMismatch
+        return Togls::RuleFeatureMismatchToggle.new
       end
     end
 

--- a/spec/togls/feature_repository_spec.rb
+++ b/spec/togls/feature_repository_spec.rb
@@ -58,9 +58,9 @@ describe Togls::FeatureRepository do
 
   describe "#extract_feature_data" do
     it "returns the feature's extracted feature data" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :some_target_type)
       expect(subject.extract_feature_data(feature))
-        .to eq({ "key" => "some_feature_key", "description" => "Some Feature Desc" })
+        .to eq({ "key" => "some_feature_key", "description" => "Some Feature Desc", "target_type" => "some_target_type" })
     end
   end
 
@@ -177,14 +177,26 @@ describe Togls::FeatureRepository do
 
   describe "#reconstitute_feature" do
     it "constructs a feature from the feature data" do
-      expect(Togls::Feature).to receive(:new).with("some_key", "Your mom")
-      subject.reconstitute_feature({ "key" => "some_key", "description" => "Your mom" })
+      expect(Togls::Feature).to receive(:new).with("some_key", "some desc",
+                                                   :some_target_type)
+      subject.reconstitute_feature({ "key" => "some_key",
+                                     "description" => "some desc",
+                                     "target_type" => "some_target_type" })
+    end
+
+    context 'when feature data is missing target_type' do
+      it 'constructs a feature with a default target type' do
+        expect(Togls::Feature).to receive(:new).with("some_key", "some desc")
+        subject.reconstitute_feature({ "key" => "some_key",
+                                       "description" => "some desc" })
+      end
     end
 
     it "returns the feature" do
       feature = double('feature')
       allow(Togls::Feature).to receive(:new).and_return(feature)
-      subject.reconstitute_feature({ "key" => "some_key", "description" => "Your mom" })
+      expect(subject.reconstitute_feature({ "key" => "some_key", "description" => "some desc",
+                                            "target_type" => 'some target type' })).to eq(feature)
     end
   end
 end

--- a/spec/togls/feature_spec.rb
+++ b/spec/togls/feature_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Togls::Feature do
-  subject { Togls::Feature.new(:key, "some description") }
+  subject { Togls::Feature.new(:key, "some description", :foo_target_type) }
 
   describe "#initialize" do
     it "assigns the passed key" do
@@ -11,11 +11,29 @@ describe Togls::Feature do
     it "assigns the description" do
       expect(subject.description).to eq("some description")
     end
+
+    it 'assigns the given target_type' do
+      expect(subject.target_type).to eq(:foo_target_type)
+    end
+
+    context 'when constructed without a target_type' do
+      subject { Togls::Feature.new(:key, 'some description') }
+
+      it 'assigns the target_type to :any' do
+        expect(subject.target_type).to eq(:any)
+      end
+    end
   end
 
   describe "#description" do
     it "returns the description" do
       expect(subject.description).to eq("some description")
+    end
+  end
+
+  describe '#target_type' do
+    it 'returns the target_type' do
+      expect(subject.target_type).to eq(:foo_target_type)
     end
   end
 

--- a/spec/togls/feature_spec.rb
+++ b/spec/togls/feature_spec.rb
@@ -20,7 +20,7 @@ describe Togls::Feature do
       subject { Togls::Feature.new(:key, 'some description') }
 
       it 'assigns the target_type to :any' do
-        expect(subject.target_type).to eq(:any)
+        expect(subject.target_type).to eq(Togls::TargetTypes::ANY)
       end
     end
   end

--- a/spec/togls/feature_spec.rb
+++ b/spec/togls/feature_spec.rb
@@ -19,7 +19,7 @@ describe Togls::Feature do
     context 'when constructed without a target_type' do
       subject { Togls::Feature.new(:key, 'some description') }
 
-      it 'assigns the target_type to :any' do
+      it 'assigns the target_type to ANY' do
         expect(subject.target_type).to eq(Togls::TargetTypes::ANY)
       end
     end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -16,7 +16,7 @@ describe Togls::Rule do
   end
 
   describe '.target_type' do
-    it 'returns the default of :any' do
+    it 'returns the default of ANY' do
       klass = Class.new(Togls::Rule)
       expect(klass.target_type).to eq(Togls::TargetTypes::ANY)
     end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -18,7 +18,7 @@ describe Togls::Rule do
   describe '.target_type' do
     it 'returns the default of :any' do
       klass = Class.new(Togls::Rule)
-      expect(klass.target_type).to eq(:any)
+      expect(klass.target_type).to eq(Togls::TargetTypes::ANY)
     end
   end
 

--- a/spec/togls/rules/boolean_spec.rb
+++ b/spec/togls/rules/boolean_spec.rb
@@ -15,7 +15,7 @@ describe Togls::Rules::Boolean do
 
   describe '.target_type' do
     it 'returns :any' do
-      expect(Togls::Rules::Boolean.target_type).to eq(:any)
+      expect(Togls::Rules::Boolean.target_type).to eq(Togls::TargetTypes::ANY)
     end
   end
 

--- a/spec/togls/rules/boolean_spec.rb
+++ b/spec/togls/rules/boolean_spec.rb
@@ -14,7 +14,7 @@ describe Togls::Rules::Boolean do
   end
 
   describe '.target_type' do
-    it 'returns :any' do
+    it 'returns ANY' do
       expect(Togls::Rules::Boolean.target_type).to eq(Togls::TargetTypes::ANY)
     end
   end

--- a/spec/togls/rules/group_spec.rb
+++ b/spec/togls/rules/group_spec.rb
@@ -15,7 +15,7 @@ describe Togls::Rules::Group do
 
   describe '.target_type' do
     it 'returns :any' do
-      expect(Togls::Rules::Group.target_type).to eq(:any)
+      expect(Togls::Rules::Group.target_type).to eq(Togls::TargetTypes::ANY)
     end
   end
 

--- a/spec/togls/rules/group_spec.rb
+++ b/spec/togls/rules/group_spec.rb
@@ -14,7 +14,7 @@ describe Togls::Rules::Group do
   end
 
   describe '.target_type' do
-    it 'returns :any' do
+    it 'returns ANY' do
       expect(Togls::Rules::Group.target_type).to eq(Togls::TargetTypes::ANY)
     end
   end

--- a/spec/togls/toggle_registry_spec.rb
+++ b/spec/togls/toggle_registry_spec.rb
@@ -155,7 +155,7 @@ describe Togls::ToggleRegistry do
 
     context 'when a rule miss-match is detected' do
       before do
-        toggle = Togls::RuleFeatureMissMatchToggle.new
+        toggle = Togls::RuleFeatureMismatchToggle.new
         toggle_repository = subject.instance_variable_get(:@toggle_repository)
         allow(toggle_repository).to receive(:get).and_return(toggle)
       end
@@ -166,7 +166,7 @@ describe Togls::ToggleRegistry do
       end
 
       it "returns a null toggle" do
-        expect(subject.get("some not real key")).to be_a(Togls::RuleFeatureMissMatchToggle)
+        expect(subject.get("some not real key")).to be_a(Togls::RuleFeatureMismatchToggle)
       end
     end
   end

--- a/spec/togls/toggle_registry_spec.rb
+++ b/spec/togls/toggle_registry_spec.rb
@@ -152,23 +152,6 @@ describe Togls::ToggleRegistry do
         expect(subject.get("some not real key")).to be_a(Togls::ToggleMissingToggle)
       end
     end
-
-    context 'when a rule mismatch is detected' do
-      before do
-        toggle = Togls::RuleFeatureMismatchToggle.new
-        toggle_repository = subject.instance_variable_get(:@toggle_repository)
-        allow(toggle_repository).to receive(:get).and_return(toggle)
-      end
-
-      it "logs a warning" do
-        expect(Togls.logger).to receive(:warn).with("Feature identified by 'some_id' has a rule mismatch")
-        subject.get("some_id")
-      end
-
-      it "returns a null toggle" do
-        expect(subject.get("some not real key")).to be_a(Togls::RuleFeatureMismatchToggle)
-      end
-    end
   end
 
   describe "#all" do

--- a/spec/togls/toggle_registry_spec.rb
+++ b/spec/togls/toggle_registry_spec.rb
@@ -153,7 +153,7 @@ describe Togls::ToggleRegistry do
       end
     end
 
-    context 'when a rule miss-match is detected' do
+    context 'when a rule mismatch is detected' do
       before do
         toggle = Togls::RuleFeatureMismatchToggle.new
         toggle_repository = subject.instance_variable_get(:@toggle_repository)
@@ -161,7 +161,7 @@ describe Togls::ToggleRegistry do
       end
 
       it "logs a warning" do
-        expect(Togls.logger).to receive(:warn).with("Feature identified by 'some_id' has a rule miss-match")
+        expect(Togls.logger).to receive(:warn).with("Feature identified by 'some_id' has a rule mismatch")
         subject.get("some_id")
       end
 

--- a/spec/togls/toggle_registry_spec.rb
+++ b/spec/togls/toggle_registry_spec.rb
@@ -52,12 +52,13 @@ describe Togls::ToggleRegistry do
       subject.feature(:some_key, "description")
     end
 
-    it "creates a new feature object with the passed key" do
+    it "creates a new feature object with the passed key and target type" do
       desc = double('feature desc')
-      key = "some_key"
-      feature = Togls::Feature.new('some_feature_key', "Some Feature Desc")
-      expect(Togls::Feature).to receive(:new).with(key, desc).and_return(feature)
-      subject.feature(key, desc)
+      key = 'some_key'
+      target_type = :some_target_type
+      feature = Togls::Feature.new('some_feature_key', 'Some Feature Desc', :some_target_type)
+      expect(Togls::Feature).to receive(:new).with(key, desc, target_type).and_return(feature)
+      subject.feature(key, desc, target_type: :some_target_type)
     end
     
     it "creates a feature toggle with the created feature" do
@@ -137,9 +138,9 @@ describe Togls::ToggleRegistry do
 
     context "when the toggle is NOT found" do
       before do
-        null_toggle = Togls::NullToggle.new
+        toggle_missing_toggle = Togls::ToggleMissingToggle.new
         toggle_repository = subject.instance_variable_get(:@toggle_repository)
-        allow(toggle_repository).to receive(:get).and_return(null_toggle)
+        allow(toggle_repository).to receive(:get).and_return(toggle_missing_toggle)
       end
 
       it "logs a warning" do
@@ -148,7 +149,24 @@ describe Togls::ToggleRegistry do
       end
 
       it "returns a null toggle" do
-        expect(subject.get("some not real key")).to be_a(Togls::NullToggle)
+        expect(subject.get("some not real key")).to be_a(Togls::ToggleMissingToggle)
+      end
+    end
+
+    context 'when a rule miss-match is detected' do
+      before do
+        toggle = Togls::RuleFeatureMissMatchToggle.new
+        toggle_repository = subject.instance_variable_get(:@toggle_repository)
+        allow(toggle_repository).to receive(:get).and_return(toggle)
+      end
+
+      it "logs a warning" do
+        expect(Togls.logger).to receive(:warn).with("Feature identified by 'some_id' has a rule miss-match")
+        subject.get("some_id")
+      end
+
+      it "returns a null toggle" do
+        expect(subject.get("some not real key")).to be_a(Togls::RuleFeatureMissMatchToggle)
       end
     end
   end

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -150,13 +150,13 @@ describe Togls::ToggleRepository do
       end
 
       it "constructs a null toggle" do
-        expect(Togls::NullToggle).to receive(:new)
+        expect(Togls::ToggleMissingToggle).to receive(:new)
         subject.get("some id")
       end
 
       it "returns the null toggle" do
         null_toggle = double('null toggle')
-        allow(Togls::NullToggle).to receive(:new).and_return(null_toggle)
+        allow(Togls::ToggleMissingToggle).to receive(:new).and_return(null_toggle)
         expect(subject.get("some id")).to eq(null_toggle)
       end
     end
@@ -165,18 +165,20 @@ describe Togls::ToggleRepository do
   describe "#reconstitute_toggle" do
     it "fetches the referenced feature from the feature repository" do
       toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
-      feature_repository = subject.instance_variable_get(:@feature_repository)
-      rule_repository = subject.instance_variable_get(:@rule_repository)
+      toggle = double('toggle')
       allow(rule_repository).to receive(:get)
+      allow(Togls::Toggle).to receive(:new).and_return(toggle)
+      allow(toggle).to receive(:rule=)
       expect(feature_repository).to receive(:get).with("badges")
       subject.reconstitute_toggle(toggle_data)
     end
 
     it "fetches the referenced rule from the rule repository" do
       toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
-      feature_repository = subject.instance_variable_get(:@feature_repository)
-      rule_repository = subject.instance_variable_get(:@rule_repository)
+      toggle = double('toggle')
       allow(feature_repository).to receive(:get)
+      allow(Togls::Toggle).to receive(:new).and_return(toggle)
+      allow(toggle).to receive(:rule=)
       expect(rule_repository).to receive(:get).with("ba234aoeubaooea23")
       subject.reconstitute_toggle(toggle_data)
     end
@@ -184,8 +186,6 @@ describe Togls::ToggleRepository do
     it "constructs a toggle with the fetcthed feature" do
       toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
       feature = double('feature')
-      feature_repository = subject.instance_variable_get(:@feature_repository)
-      rule_repository = subject.instance_variable_get(:@rule_repository)
       allow(rule_repository).to receive(:get)
       allow(feature_repository).to receive(:get).and_return(feature)
       expect(Togls::Toggle).to receive(:new).with(feature).and_return(double.as_null_object)
@@ -196,8 +196,6 @@ describe Togls::ToggleRepository do
       toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
       toggle = double('toggle')
       rule = double('rule')
-      feature_repository = subject.instance_variable_get(:@feature_repository)
-      rule_repository = subject.instance_variable_get(:@rule_repository)
       allow(rule_repository).to receive(:get).and_return(rule)
       allow(feature_repository).to receive(:get)
       allow(Togls::Toggle).to receive(:new).and_return(toggle)
@@ -205,17 +203,33 @@ describe Togls::ToggleRepository do
       subject.reconstitute_toggle(toggle_data)
     end
 
-    it "returns the toggle" do
-      toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
-      toggle = double('toggle')
-      rule = double('rule')
-      feature_repository = subject.instance_variable_get(:@feature_repository)
-      rule_repository = subject.instance_variable_get(:@rule_repository)
-      allow(rule_repository).to receive(:get).and_return(rule)
-      allow(feature_repository).to receive(:get)
-      allow(Togls::Toggle).to receive(:new).and_return(toggle)
-      allow(toggle).to receive(:rule=).with(rule)
-      expect(subject.reconstitute_toggle(toggle_data)).to eq(toggle)
+    context 'when rule assignment identifies a miss match' do
+      it 'returns a constructed missmatch toggle' do
+        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
+        rule = double 'rule'
+        toggle = double('toggle')
+        null_toggle = double 'null toggle'
+        allow(feature_repository).to receive(:get)
+        allow(rule_repository).to receive(:get).and_return(rule)
+        allow(Togls::Toggle).to receive(:new).and_return(toggle)
+        allow(toggle).to receive(:rule=).and_raise Togls::RuleFeatureTargetTypeMissMatch
+        allow(Togls::RuleFeatureMissMatchToggle).to receive(:new).and_return(null_toggle)
+        result = subject.reconstitute_toggle(toggle_data)
+        expect(result).to eql null_toggle
+      end
+    end
+
+    context 'when rule assignment is successful' do
+      it "returns the toggle" do
+        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
+        toggle = double('toggle')
+        rule = double('rule')
+        allow(rule_repository).to receive(:get).and_return(rule)
+        allow(feature_repository).to receive(:get)
+        allow(Togls::Toggle).to receive(:new).and_return(toggle)
+        allow(toggle).to receive(:rule=).with(rule)
+        expect(subject.reconstitute_toggle(toggle_data)).to eq(toggle)
+      end
     end
   end
 

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -203,8 +203,8 @@ describe Togls::ToggleRepository do
       subject.reconstitute_toggle(toggle_data)
     end
 
-    context 'when rule assignment identifies a miss match' do
-      it 'returns a constructed missmatch toggle' do
+    context 'when rule assignment identifies a mismatch' do
+      it 'returns a constructed mismatch toggle' do
         toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
         rule = double 'rule'
         toggle = double('toggle')

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -212,8 +212,8 @@ describe Togls::ToggleRepository do
         allow(feature_repository).to receive(:get)
         allow(rule_repository).to receive(:get).and_return(rule)
         allow(Togls::Toggle).to receive(:new).and_return(toggle)
-        allow(toggle).to receive(:rule=).and_raise Togls::RuleFeatureTargetTypeMissMatch
-        allow(Togls::RuleFeatureMissMatchToggle).to receive(:new).and_return(null_toggle)
+        allow(toggle).to receive(:rule=).and_raise Togls::RuleFeatureTargetTypeMismatch
+        allow(Togls::RuleFeatureMismatchToggle).to receive(:new).and_return(null_toggle)
         result = subject.reconstitute_toggle(toggle_data)
         expect(result).to eql null_toggle
       end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -35,7 +35,7 @@ describe Togls::Toggle do
     it "returns the rule of the toggle" do
       rule = double('rule')
       subject.instance_variable_set(:@rule, rule)
-      expect(subject.rule).to eq(rule)      
+      expect(subject.rule).to eq(rule)
     end
   end
 
@@ -48,7 +48,7 @@ describe Togls::Toggle do
     end
 
     context 'when given a rule which belongs to a class that has a mismatched target type' do
-      it 'raises a target type miss match error' do
+      it 'raises a target type mismatch error' do
         rule = double('rule')
         allow(subject).to receive(:target_matches?).and_return(false)
         expect {

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -47,7 +47,7 @@ describe Togls::Toggle do
       expect(subject.instance_variable_get(:@rule)).to eq(rule)
     end
 
-    context 'when given a rule which belongs to a class that has a miss-matched target type' do
+    context 'when given a rule which belongs to a class that has a mismatched target type' do
       it 'raises a target type miss match error' do
         rule = double('rule')
         allow(subject).to receive(:target_matches?).and_return(false)

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -53,7 +53,7 @@ describe Togls::Toggle do
         allow(subject).to receive(:target_matches?).and_return(false)
         expect {
           subject.rule = rule
-        }.to raise_error(Togls::RuleFeatureTargetTypeMissMatch)
+        }.to raise_error(Togls::RuleFeatureTargetTypeMismatch)
       end
     end
   end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -61,7 +61,7 @@ describe Togls::Toggle do
   describe '#target_matches?' do
     context 'when the rule target type matches the features target type' do
       it 'returns true' do
-        feature = Togls::Feature.new('some name', 'some desc', :hoopty) # accepts :hoopty or :any
+        feature = Togls::Feature.new('some name', 'some desc', :hoopty)
         toggle = Togls::Toggle.new(feature)
 
         rule_klass = Class.new(Togls::Rule) do
@@ -77,14 +77,14 @@ describe Togls::Toggle do
     end
 
     context 'when the rule target type does NOT match the features target type' do
-      context 'when the feature target type is for :any target type' do
+      context 'when the rule target type is for ANY target type' do
         it 'returns true' do
-          feature = Togls::Feature.new('some name', 'some desc') # accepts :hoopty or :any
+          feature = Togls::Feature.new('some name', 'some desc', :jokes)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              :hoopty
+              Togls::TargetTypes::ANY
             end
           end
           rule = rule_klass.new
@@ -94,9 +94,9 @@ describe Togls::Toggle do
         end
       end
 
-      context 'when the feature target type is NOT for :any target type' do
+      context 'when the rule target type is NOT for ANY target type' do
         it 'returns false' do
-          feature = Togls::Feature.new('some name', 'some desc', :foo) # accepts :hoopty or :any
+          feature = Togls::Feature.new('some name', 'some desc', :foo)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -169,7 +169,7 @@ describe "Togl" do
           Togls.release do
             feature(:hoopty, 'some hoopty description', target_type: :red_person).on(some_rule)
           end
-        }.to raise_error Togls::RuleFeatureTargetTypeMissMatch
+        }.to raise_error Togls::RuleFeatureTargetTypeMismatch
       end
     end
 
@@ -356,7 +356,7 @@ describe "Togl" do
         toggle.instance_variable_set(:@rule, a)
         toggle_repo.store(toggle)
 
-        expect(Togls.feature(:hoopty)).to be_a(Togls::RuleFeatureMissMatchToggle)
+        expect(Togls.feature(:hoopty)).to be_a(Togls::RuleFeatureMismatchToggle)
         expect(Togls.feature(:hoopty).on?).to eq(false)
       end
     end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -139,7 +139,7 @@ describe "Togl" do
     end
 
 
-    context 'when using a custom rule that has a miss-matched target type' do
+    context 'when using a custom rule that has a mismatched target type' do
       after do
         Object.send(:remove_const, :FooBarRule)
       end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -291,7 +291,7 @@ describe "Togl" do
       expect(Togls.feature(:not_defined).on?).to eq(false)
     end
 
-    context "when a features rule can't properly be evaluated" do
+    context "when a features rule can't properly be evaluated because of a mismatch" do
       after do
         Object.send(:remove_const, :AnotherRule)
       end


### PR DESCRIPTION
Issue #65 

The goal of this was to add support for defining abstract formalized target types in the DSL as well as implement basic target type checking and handle miss-match scenarios appropriately.