### PR TITLE
Add rule target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Added`: rule instance target types and switch type checking over
+  ([#67](https://github.com/codebreakdown/togls/issues/67))
 * `Added`: optional target types, and target type checking
   ([#65](https://github.com/codebreakdown/togls/issues/65))
 * `Changed`: rule type repository to store meta data

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -18,8 +18,9 @@ module Togls
       Togls::TargetTypes::ANY
     end
 
-    def initialize(data = nil)
+    def initialize(data = nil, target_type: nil)
       @data = data
+      @target_type = target_type
     end
 
     def run(key, target = nil)
@@ -28,6 +29,11 @@ module Togls
 
     def id
       Togls::Helpers.sha1(self.class, @data)
+    end
+
+    def target_type
+      return @target_type if @target_type
+      return self.class.target_type
     end
   end
 end

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -46,7 +46,13 @@ module Togls
     end
 
     def reconstitute_rule(rule_data)
-      @rule_type_registry.get(rule_data['type_id']).new(rule_data['data'])
+      if rule_data.has_key?('target_type')
+        @rule_type_registry.get(rule_data['type_id'])\
+          .new(rule_data['data'],
+               target_type: rule_data['target_type'].to_sym)
+      else
+        @rule_type_registry.get(rule_data['type_id']).new(rule_data['data'])
+      end
     end
   end
 end

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -24,7 +24,11 @@ module Togls
     end
 
     def extract_storage_payload(rule)
-      { 'type_id' => @rule_type_registry.get_type_id(rule.class.to_s), 'data' => rule.data }
+      {
+        'type_id' => @rule_type_registry.get_type_id(rule.class.to_s),
+        'data' => rule.data, 
+        'target_type' => rule.target_type.to_s
+      }
     end
 
     def fetch_rule_data(id)

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -29,8 +29,8 @@ module Togls
     # something (foo)     | something (foo)  | true
     # something (foo)     | something (bar)  | false
     def target_matches?(rule)
-      @feature.target_type == rule.class.target_type ||
-        rule.class.target_type == Togls::TargetTypes::ANY
+      @feature.target_type == rule.target_type ||
+        rule.target_type == Togls::TargetTypes::ANY
     end
 
     def on?(target = nil)

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -43,7 +43,7 @@ module Togls
         toggle.rule = rule
         toggle
       rescue Togls::RuleFeatureTargetTypeMismatch
-        Togls.logger.warn("Feature (#{feature.key}) with target type '#{feature.target_type}' has a rule (#{rule.id}) mismatch with target type '#{rule.class.target_type}'")
+        Togls.logger.warn("Feature (#{feature.key}) with target type '#{feature.target_type}' has a rule (#{rule.id}) mismatch with target type '#{rule.target_type}'")
         return Togls::RuleFeatureMismatchToggle.new
       end
     end

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -72,11 +72,11 @@ describe Togls::RuleRepository do
       subject.extract_storage_payload(rule)
     end
 
-    it "returns the rule's extracted storage payload" do
-      rule = Togls::Rule.new(true)
+    it 'returns the rule\'s extracted storage payload without the target_type' do
+      rule = Togls::Rule.new(true, target_type: :foo)
       allow(rule_type_registry).to receive(:get_type_id).with('Togls::Rule').and_return('hoopty')
       expect(subject.extract_storage_payload(rule))
-        .to eq({ 'type_id' => 'hoopty', 'data' => true })
+        .to eq({ 'type_id' => 'hoopty', 'data' => true, 'target_type' => 'foo' })
     end
   end
 

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -72,7 +72,7 @@ describe Togls::RuleRepository do
       subject.extract_storage_payload(rule)
     end
 
-    it 'returns the rule\'s extracted storage payload without the target_type' do
+    it 'returns the rule\'s extracted storage payload with the target_type' do
       rule = Togls::Rule.new(true, target_type: :foo)
       allow(rule_type_registry).to receive(:get_type_id).with('Togls::Rule').and_return('hoopty')
       expect(subject.extract_storage_payload(rule))

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -171,10 +171,20 @@ describe Togls::RuleRepository do
   end
 
   describe '#reconstitute_rule' do
-    it 'constructs a rule from the rule data' do
-      allow(rule_type_registry).to receive(:get).with('boolean').and_return(Togls::Rules::Boolean)
-      expect(Togls::Rules::Boolean).to receive(:new).with(true)
-      subject.reconstitute_rule({ 'type_id' => 'boolean', 'data' => true })
+    context 'when rule data has target_type' do
+      it 'constructs a rule with the target type' do
+        allow(rule_type_registry).to receive(:get).with('boolean').and_return(Togls::Rules::Boolean)
+        expect(Togls::Rules::Boolean).to receive(:new).with(true, target_type: :foo)
+        subject.reconstitute_rule({ 'type_id' => 'boolean', 'data' => true, 'target_type' => 'foo' })
+      end
+    end
+
+    context 'when rule data does NOT have a target_type' do
+      it 'constructs a rule without a target_type' do
+        allow(rule_type_registry).to receive(:get).with('boolean').and_return(Togls::Rules::Boolean)
+        expect(Togls::Rules::Boolean).to receive(:new).with(true)
+        subject.reconstitute_rule({ 'type_id' => 'boolean', 'data' => true })
+      end
     end
 
     it 'returns the rule' do

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -22,11 +22,33 @@ describe Togls::Rule do
     end
   end
 
-  describe "#initialize" do
-    it "assigns the given data to an instance variable" do
-      data = double('data')
-      rule = Togls::Rule.new(data)
-      expect(rule.instance_variable_get(:@data)).to eq(data)
+  describe '#initialize' do
+    context 'when just given intialization data' do
+      it 'assigns the given data to an instance variable' do
+        data = double('data')
+        rule = Togls::Rule.new(data)
+        expect(rule.instance_variable_get(:@data)).to eq(data)
+      end
+
+      it 'assigns the target type instance variable to nil' do
+        data = double('data')
+        rule = Togls::Rule.new(data)
+        expect(rule.instance_variable_get(:@target_type)).to be_nil
+      end
+    end
+
+    context 'when given initialization data and target_type' do
+      it 'assigns the given data to an instance variable' do
+        data = double('data')
+        rule = Togls::Rule.new(data, target_type: :some_target_type)
+        expect(rule.instance_variable_get(:@data)).to eq(data)
+      end
+
+      it 'assigns the given target type to an instance variable' do
+        data = double('data')
+        rule = Togls::Rule.new(data, target_type: :some_target_type)
+        expect(rule.instance_variable_get(:@target_type)).to eq(:some_target_type)
+      end
     end
   end
 
@@ -57,6 +79,28 @@ describe Togls::Rule do
     it "returns the data it was initially initialized with" do
       rule = Togls::Rule.new("test value")
       expect(rule.data).to eq("test value")
+    end
+  end
+
+  describe '#target_type' do
+    context 'when the rule instance has a target type' do
+      it 'returns the rule instances target type' do
+        rule = Togls::Rule.new('some data', target_type: :hoopty)
+        expect(rule.target_type).to eq(:hoopty)
+      end
+    end
+
+    context 'when the rule instance has NO target type' do
+      it 'returns the rule type target type' do
+        rule_klass = Class.new(Togls::Rule) do
+          def self.target_type
+            :woot_woot
+          end
+        end
+
+        rule = rule_klass.new('some data')
+        expect(rule.target_type).to eq(:woot_woot)
+      end
     end
   end
 end

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -206,8 +206,7 @@ describe Togls::ToggleRepository do
     context 'when rule assignment identifies a mismatch' do
       it 'logs the mismatch' do
         toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
-        rule_type = double('rule_type', target_type: 'janky')
-        rule = double('rule', id: 'someid', class: rule_type)
+        rule = double('rule', id: 'someid', target_type: 'janky')
         feature = double('feature', key: 'feature_key', target_type: 'hoopty')
         toggle = double('toggle')
         null_toggle = double 'null toggle'
@@ -222,8 +221,7 @@ describe Togls::ToggleRepository do
 
       it 'returns a constructed mismatch toggle' do
         toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
-        rule_type = double('rule_type', target_type: 'janky')
-        rule = double('rule', id: 'someid', class: rule_type)
+        rule = double('rule', id: 'someid', target_type: 'janky')
         toggle = double('toggle')
         feature = double('feature', key: 'feature_key', target_type: 'hoopty')
         null_toggle = double 'null toggle'

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -59,32 +59,15 @@ describe Togls::Toggle do
   end
 
   describe '#target_matches?' do
-    context 'when the rule target type matches the features target type' do
-      it 'returns true' do
-        feature = Togls::Feature.new('some name', 'some desc', :hoopty)
-        toggle = Togls::Toggle.new(feature)
-
-        rule_klass = Class.new(Togls::Rule) do
-          def self.target_type
-            :hoopty
-          end
-        end
-        rule = rule_klass.new
-
-        result = toggle.target_matches?(rule)
-        expect(result).to eql true
-      end
-    end
-
-    context 'when the rule target type does NOT match the features target type' do
-      context 'when the rule target type is for ANY target type' do
+    context 'when the rule has no target type' do
+      context 'when the rule types target type matches the features target type' do
         it 'returns true' do
-          feature = Togls::Feature.new('some name', 'some desc', :jokes)
+          feature = Togls::Feature.new('some name', 'some desc', :hoopty)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              Togls::TargetTypes::ANY
+              :hoopty
             end
           end
           rule = rule_klass.new
@@ -94,20 +77,79 @@ describe Togls::Toggle do
         end
       end
 
-      context 'when the rule target type is NOT for ANY target type' do
-        it 'returns false' do
-          feature = Togls::Feature.new('some name', 'some desc', :foo)
+      context 'when the rule types target type does NOT match the features target type' do
+        context 'when the rule types target type is for ANY target type' do
+          it 'returns true' do
+            feature = Togls::Feature.new('some name', 'some desc', :jokes)
+            toggle = Togls::Toggle.new(feature)
+
+            rule_klass = Class.new(Togls::Rule) do
+              def self.target_type
+                Togls::TargetTypes::ANY
+              end
+            end
+            rule = rule_klass.new
+
+            result = toggle.target_matches?(rule)
+            expect(result).to eql true
+          end
+        end
+
+        context 'when the rule types target type is NOT for ANY target type' do
+          it 'returns false' do
+            feature = Togls::Feature.new('some name', 'some desc', :foo)
+            toggle = Togls::Toggle.new(feature)
+
+            rule_klass = Class.new(Togls::Rule) do
+              def self.target_type
+                :bar
+              end
+            end
+            rule = rule_klass.new
+
+            result = toggle.target_matches?(rule)
+            expect(result).to eql false
+          end
+        end
+      end
+    end
+
+    context 'when the rule has a target type' do
+      context 'when the rule target type matches the features target type' do
+        it 'returns true' do
+          feature = Togls::Feature.new('some name', 'some desc', :hoopty)
           toggle = Togls::Toggle.new(feature)
 
-          rule_klass = Class.new(Togls::Rule) do
-            def self.target_type
-              :bar
-            end
-          end
-          rule = rule_klass.new
+          rule = Togls::Rule.new('something', target_type: :hoopty)
 
           result = toggle.target_matches?(rule)
-          expect(result).to eql false
+          expect(result).to eql true
+        end
+      end
+
+      context 'when the rule target type does NOT match the features target type' do
+        context 'when the rule target type is for ANY target type' do
+          it 'returns true' do
+            feature = Togls::Feature.new('some name', 'some desc', :hoopty)
+            toggle = Togls::Toggle.new(feature)
+
+            rule = Togls::Rule.new('something', target_type: Togls::TargetTypes::ANY)
+
+            result = toggle.target_matches?(rule)
+            expect(result).to eql true
+          end
+        end
+
+        context 'when the rule target type is NOT for ANY target type' do
+          it 'returns false' do
+            feature = Togls::Feature.new('some name', 'some desc', :hoopty)
+            toggle = Togls::Toggle.new(feature)
+
+            rule = Togls::Rule.new('something', target_type: :bar)
+
+            result = toggle.target_matches?(rule)
+            expect(result).to eql false
+          end
         end
       end
     end


### PR DESCRIPTION
This PR intends to add rule instance target_types so that instances of rules can have a specified target_type. This PR relates to issue #67.

#### Modify RuleRepository to store target_type
    
Why you made the change:
    
I did this so that when the RuleRepository attempts to store a rule it now
stores the target_type associated with that rule along with the data and type
information it was previously storing.

#### Add ability for Rules to have a target_type
    
Why you made the change:
    
I did this because I want to add support for in code and externally defined
rules to be able to specify a given target_type. That way for example if you
were defining a rule instance called alpha_testers from the Group rule you would
be able to type match appropriately. For example:
    
    alpha_testers = Togls::Rules::Group.new([323, 11, 34, 123], target_type: :user_id)
    
This would allow us to do checking based on the instance which if it doesn't
have a target_type falls back to the class (a.k.a. rule type). If we were to do
the following:
    
    alpha_testers = Togls::Rules::Group.new([323, 11, 34, 123])
    
Then it would simply be a rule with a target_type of ANY which doesn't really
bring any additional safety in terms of these abstract formalized target types.
    
Note: This change is just in preparation for this is support. It does not modify
the type checking to use this, nor does it support reconstitution of rules with
an optional target_type. Both of these things would have to happen in order to
support this concept fully.

####  Add rule reconstitution with target_type
    
Why you made the change:
    
I did this so that if any of the rule repository drivers returned a target_type
then it would be used to construct the associated rule when it is reconstituted.
If no target_type is present then it will simply construct the rule without one,
in turn having that rule default to the rule type's target_type.

#### Modify target type, type checking to use rule target type
    
Why you made the change:
    
I did this because the necessary dependencies to support this functionality have
been put in place in a backwards compatible fashion. This will enable users to
specify target types specific to a given rule instance optionally. If it isn't
specified on the rule instance the rule instance target type will fall back to
the target type of that rule instances rule type.
