### PR TITLE
Correct target type checking logic

### DIFF
--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -4,12 +4,17 @@ module Togls
   # The Feature model is the business representation of a feature. It is how
   # Togls primarily interfaces with the concept of a feature.
   class Feature
-    attr_reader :key, :description, :target_type
+    attr_reader :key, :description
 
     def initialize(key, description, target_type = Togls::TargetTypes::NOT_SET)
       @key = key.to_s
       @description = description
       @target_type = target_type
+    end
+
+    def target_type
+      return @target_type unless @target_type.nil?
+      return Togls::TargetTypes::NOT_SET
     end
 
     def id

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -33,7 +33,8 @@ module Togls
 
     def target_type
       return @target_type if @target_type && @target_type != Togls::TargetTypes::NOT_SET
-      return self.class.target_type
+      return self.class.target_type unless self.class.target_type.nil?
+      return Togls::TargetTypes::NOT_SET
     end
   end
 end

--- a/lib/togls/rules/boolean.rb
+++ b/lib/togls/rules/boolean.rb
@@ -31,6 +31,10 @@ Togls::Rules::Boolean.new(false) # rule that always evaluates to off
         }
       end
 
+      def self.target_type
+        Togls::TargetTypes::NONE
+      end
+
       def run(_key, _target = nil)
         @data
       end

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -33,10 +33,16 @@ module Togls
     # something (foo)     | something (foo)  | true   |
     # something (foo)     | NOT_SET          | false  | broken - shouldn't happen
     # something (foo)     | something (bar)  | false  |
-    # something (bar)     | something (foo)  | false  |
     def target_matches?(rule)
-      @feature.target_type == rule.target_type ||
-        rule.target_type == Togls::TargetTypes::NOT_SET
+      if rule.target_type == Togls::TargetTypes::NONE
+        return true
+      elsif rule.target_type == Togls::TargetTypes::NOT_SET
+        return false
+      elsif rule.target_type == @feature.target_type
+        return true
+      else
+        false
+      end
     end
 
     def on?(target = nil)

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -52,15 +52,5 @@ module Togls
     def off?(target = nil)
       !@rule.run(@feature.key, target)
     end
-
-    def to_s
-      display_value = if @rule.is_a?(Togls::Rules::Boolean)
-                        @rule.run(@feature.key) ? ' on' : 'off'
-                      else
-                        '  ?'
-                      end
-
-      "#{display_value} - #{@feature.key} - #{@feature.description}"
-    end
   end
 end

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -21,13 +21,19 @@ module Togls
       @rule = rule
     end
 
-    # feature target type | rule target type | match?
-    # ------------------------------------------------
-    # not set             | not set          | true
-    # something (foo)     | not set          | true
-    # not set             | something (foo)  | false
-    # something (foo)     | something (foo)  | true
-    # something (foo)     | something (bar)  | false
+    # feature target type | rule target type | match? | notes
+    # -------------------------------------------------------
+    # NOT_SET             | NOT_SET          | false  | broken - shouldn't happen
+    # NOT_SET             | NONE             | true   |
+    # NOT_SET             | something (foo)  | false  | broken - shouldn't happen
+    # NONE                | NONE             | true   |
+    # NONE                | something (foo)  | false  |
+    # NONE                | NOT_SET          | false  | broken - shouldn't happen
+    # something (foo)     | NONE             | true   |
+    # something (foo)     | something (foo)  | true   |
+    # something (foo)     | NOT_SET          | false  | broken - shouldn't happen
+    # something (foo)     | something (bar)  | false  |
+    # something (bar)     | something (foo)  | false  |
     def target_matches?(rule)
       @feature.target_type == rule.target_type ||
         rule.target_type == Togls::TargetTypes::NOT_SET

--- a/spec/togls/feature_spec.rb
+++ b/spec/togls/feature_spec.rb
@@ -32,8 +32,18 @@ describe Togls::Feature do
   end
 
   describe '#target_type' do
-    it 'returns the target_type' do
-      expect(subject.target_type).to eq(:foo_target_type)
+    context 'when the target type is NOT nil' do
+      it 'returns the target_type' do
+        expect(subject.target_type).to eq(:foo_target_type)
+      end
+    end
+
+    context 'when the target type is nil' do
+      subject { Togls::Feature.new(:key, 'some description', nil) }
+
+      it 'returns a not set target type' do
+        expect(subject.target_type).to eq(Togls::TargetTypes::NOT_SET)
+      end
     end
   end
 

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -90,16 +90,31 @@ describe Togls::Rule do
       end
     end
 
-    context 'when the rule instance has NO target type' do
-      it 'returns the rule type target type' do
-        rule_klass = Class.new(Togls::Rule) do
-          def self.target_type
-            :woot_woot
+    context 'when the rule instance has NO target type or is NOT_SET' do
+      context 'the class target type is nil' do
+        it 'returns the rule type target type' do
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              nil
+            end
           end
-        end
 
-        rule = rule_klass.new('some data')
-        expect(rule.target_type).to eq(:woot_woot)
+          rule = rule_klass.new('some data')
+          expect(rule.target_type).to eq(Togls::TargetTypes::NOT_SET)
+        end
+      end
+
+      context 'when the class target type is NOT nil' do
+        it 'returns the rule type target type' do
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              :woot_woot
+            end
+          end
+
+          rule = rule_klass.new('some data')
+          expect(rule.target_type).to eq(:woot_woot)
+        end
       end
     end
   end

--- a/spec/togls/rules/boolean_spec.rb
+++ b/spec/togls/rules/boolean_spec.rb
@@ -15,7 +15,7 @@ describe Togls::Rules::Boolean do
 
   describe '.target_type' do
     it 'returns not set' do
-      expect(Togls::Rules::Boolean.target_type).to eq(Togls::TargetTypes::NOT_SET)
+      expect(Togls::Rules::Boolean.target_type).to eq(Togls::TargetTypes::NONE)
     end
   end
 

--- a/spec/togls/rules/boolean_spec.rb
+++ b/spec/togls/rules/boolean_spec.rb
@@ -14,7 +14,7 @@ describe Togls::Rules::Boolean do
   end
 
   describe '.target_type' do
-    it 'returns not set' do
+    it 'returns none' do
       expect(Togls::Rules::Boolean.target_type).to eq(Togls::TargetTypes::NONE)
     end
   end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -59,15 +59,32 @@ describe Togls::Toggle do
   end
 
   describe '#target_matches?' do
-    context 'when the rule has no target type' do
-      context 'when the rule types target type matches the features target type' do
-        it 'returns true' do
-          feature = Togls::Feature.new('some name', 'some desc', :hoopty)
+    context 'when the features target type is not set' do
+      context 'when the rules target type is not set' do
+        it 'returns false' do
+          feature = Togls::Feature.new('some name', 'some desc')
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              :hoopty
+              Togls::TargetTypes::NOT_SET
+            end
+          end
+          rule = rule_klass.new
+
+          result = toggle.target_matches?(rule)
+          expect(result).to eql false
+        end
+      end
+
+      context 'when the rules target type is set to none' do
+        it 'returns true' do
+          feature = Togls::Feature.new('some name', 'some desc')
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NONE
             end
           end
           rule = rule_klass.new
@@ -77,79 +94,143 @@ describe Togls::Toggle do
         end
       end
 
-      context 'when the rule types target type does NOT match the features target type' do
-        context 'when the rule types target type has not been set' do
-          it 'returns true' do
-            feature = Togls::Feature.new('some name', 'some desc', :jokes)
-            toggle = Togls::Toggle.new(feature)
+      context 'when the rules target type is specified' do
+        it 'returns false' do
+          feature = Togls::Feature.new('some name', 'some desc')
+          toggle = Togls::Toggle.new(feature)
 
-            rule_klass = Class.new(Togls::Rule) do
-              def self.target_type
-                Togls::TargetTypes::NOT_SET
-              end
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              :foo
             end
-            rule = rule_klass.new
-
-            result = toggle.target_matches?(rule)
-            expect(result).to eql true
           end
-        end
+          rule = rule_klass.new
 
-        context 'when the rule types target type is set but different from the feature' do
-          it 'returns false' do
-            feature = Togls::Feature.new('some name', 'some desc', :foo)
-            toggle = Togls::Toggle.new(feature)
-
-            rule_klass = Class.new(Togls::Rule) do
-              def self.target_type
-                :bar
-              end
-            end
-            rule = rule_klass.new
-
-            result = toggle.target_matches?(rule)
-            expect(result).to eql false
-          end
+          result = toggle.target_matches?(rule)
+          expect(result).to eql false
         end
       end
     end
 
-    context 'when the rule has a target type' do
-      context 'when the rule target type matches the features target type' do
+    context 'when the features target type is set to none' do
+      context 'when the rules target type is set to none' do
         it 'returns true' do
-          feature = Togls::Feature.new('some name', 'some desc', :hoopty)
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
           toggle = Togls::Toggle.new(feature)
 
-          rule = Togls::Rule.new('something', target_type: :hoopty)
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NONE
+            end
+          end
+          rule = rule_klass.new
 
           result = toggle.target_matches?(rule)
           expect(result).to eql true
         end
       end
 
-      context 'when the rule target type does NOT match the features target type' do
-        context 'when the rule target type is not set target type' do
-          it 'returns true' do
-            feature = Togls::Feature.new('some name', 'some desc', :hoopty)
-            toggle = Togls::Toggle.new(feature)
+      context 'when the rules target type is specified' do
+        it 'returns false' do
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          toggle = Togls::Toggle.new(feature)
 
-            rule = Togls::Rule.new('something', target_type: Togls::TargetTypes::NOT_SET)
-
-            result = toggle.target_matches?(rule)
-            expect(result).to eql true
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              :foo
+            end
           end
+          rule = rule_klass.new
+
+          result = toggle.target_matches?(rule)
+          expect(result).to eql false
         end
+      end
 
-        context 'when the rule target type has been set' do
-          it 'returns false' do
-            feature = Togls::Feature.new('some name', 'some desc', :hoopty)
-            toggle = Togls::Toggle.new(feature)
+      context 'when the rules target type is not set' do
+        it 'returns false' do
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          toggle = Togls::Toggle.new(feature)
 
-            rule = Togls::Rule.new('something', target_type: :bar)
-
-            result = toggle.target_matches?(rule)
-            expect(result).to eql false
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NOT_SET
+            end
           end
+          rule = rule_klass.new
+
+          result = toggle.target_matches?(rule)
+          expect(result).to eql false
+        end
+      end
+    end
+
+    context 'when the features target type is specified' do
+      context 'when the rules target type is set to none' do
+        it 'returns true' do
+          feature = Togls::Feature.new('some name', 'some desc', :foo)
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NONE
+            end
+          end
+          rule = rule_klass.new
+
+          result = toggle.target_matches?(rule)
+          expect(result).to eql true
+        end
+      end
+
+      context 'when the rules target type is explicitly set to match' do
+        it 'returns true' do
+          feature = Togls::Feature.new('some name', 'some desc', :foo)
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              :foo
+            end
+          end
+          rule = rule_klass.new
+
+          result = toggle.target_matches?(rule)
+          expect(result).to eql true
+        end
+      end
+
+      context 'when the rules target type is not set' do
+        it 'returns false' do
+          feature = Togls::Feature.new('some name', 'some desc', :foo)
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NOT_SET
+            end
+          end
+          rule = rule_klass.new
+
+          result = toggle.target_matches?(rule)
+          expect(result).to eql false
+        end
+      end
+
+      context 'when the rules target type is explicitly set to NOT match' do
+        it 'returns false' do
+          feature = Togls::Feature.new('some name', 'some desc', :foo)
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              :bar
+            end
+          end
+          rule = rule_klass.new
+
+          result = toggle.target_matches?(rule)
+          expect(result).to eql false
         end
       end
     end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -277,23 +277,4 @@ describe Togls::Toggle do
       expect(subject.off?(target)).to eq(true)
     end
   end
-
-  describe "#to_s" do
-    context "when based on boolean rule" do
-      it "returns a human readable string representation of the feature including value" do
-        toggle = Togls::Toggle.new(Togls::Feature.new(:key, "some description"))
-        toggle.rule = Togls::Rules::Boolean.new(true)
-        expect(toggle.to_s).to eq(" on - key - some description")
-      end
-    end
-
-    context "when NOT based on boolean rule" do
-      it "returns a human readable string representation of the feature with an unknown value" do
-        rule = Togls::Rule.new(true)
-        toggle = Togls::Toggle.new(Togls::Feature.new(:another_key, "another description"))
-        toggle.rule = rule
-        expect(toggle.to_s).to eq("  ? - another_key - another description")
-      end
-    end
-  end
 end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -130,8 +130,8 @@ describe "Togl" do
 
     it "creates a new feature with a group" do
       Togls.release do
-        rule = Togls::Rules::Group.new(["someone"])
-        feature(:test, "some human readable description").on(rule)
+        rule = Togls::Rules::Group.new(["someone"], target_type: :foo)
+        feature(:test, "some human readable description", target_type: :foo).on(rule)
       end
 
       expect(Togls.feature(:test).on?("someone")).to eq(true)


### PR DESCRIPTION
relates to https://github.com/codebreakdown/togls/issues/73

I did this so that we can verify that the rule and feature can be evaluated
properly. If there is a mismatch it will return false and later return a type
of null toggle. This requires us to change the boolean rule to have the
correct default target type of NONE instead of being NOT_SET.