### PR TITLE
Make rule require target type to construct

### DIFF
--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -7,4 +7,5 @@ module Togls
   class FeatureAlreadyDefined < Error; end
   class RuleTypeAlreadyDefined < Error; end
   class RuleFeatureTargetTypeMismatch < Error; end
+  class RuleMissingTargetType < Error; end
 end

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -21,6 +21,7 @@ module Togls
     def initialize(data = nil, target_type: Togls::TargetTypes::NOT_SET)
       @data = data
       @target_type = target_type
+      raise Togls::RuleMissingTargetType, "Rule '#{self.id}' of type '#{self.class}' is missing a required target type" if self.missing_target_type?
     end
 
     def run(key, target = nil)
@@ -35,6 +36,11 @@ module Togls
       return @target_type if @target_type && @target_type != Togls::TargetTypes::NOT_SET
       return self.class.target_type unless self.class.target_type.nil?
       return Togls::TargetTypes::NOT_SET
+    end
+
+    def missing_target_type?
+      return false if target_type && (target_type != Togls::TargetTypes::NOT_SET)
+      return true
     end
   end
 end

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -42,7 +42,7 @@ describe Togls::RuleRepository do
 
   describe "#store" do
     it "gets the storage payload" do
-      rule = Togls::Rule.new
+      rule = Togls::Rule.new('something', target_type: :foo)
       allow(driver).to receive(:store)
       expect(subject).to receive(:extract_storage_payload).with(rule)
       subject.store(rule)
@@ -56,7 +56,7 @@ describe Togls::RuleRepository do
     end
 
     it "store the rule data in each driver" do
-      rule = Togls::Rule.new(true)
+      rule = Togls::Rule.new(true, target_type: :foo)
       rule_data = double('rule data')
       allow(subject).to receive(:extract_storage_payload).and_return(rule_data)
       allow(subject.instance_variable_get(:@drivers)).to receive(:each).and_yield(driver)
@@ -67,7 +67,7 @@ describe Togls::RuleRepository do
 
   describe "#extract_storage_payload" do
     it 'gets the rule_type_id from rule type repository' do
-      rule = Togls::Rule.new(true)
+      rule = Togls::Rule.new(true, target_type: :foo)
       expect(rule_type_registry).to receive(:get_type_id).with('Togls::Rule')
       subject.extract_storage_payload(rule)
     end

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -42,7 +42,7 @@ describe Togls::RuleRepository do
 
   describe "#store" do
     it "gets the storage payload" do
-      rule = Togls::Rule.new('something', target_type: :foo)
+      rule = Togls::Rule.new(target_type: :foo)
       allow(driver).to receive(:store)
       expect(subject).to receive(:extract_storage_payload).with(rule)
       subject.store(rule)
@@ -56,7 +56,7 @@ describe Togls::RuleRepository do
     end
 
     it "store the rule data in each driver" do
-      rule = Togls::Rule.new(true, target_type: :foo)
+      rule = Togls::Rule.new(target_type: :foo)
       rule_data = double('rule data')
       allow(subject).to receive(:extract_storage_payload).and_return(rule_data)
       allow(subject.instance_variable_get(:@drivers)).to receive(:each).and_yield(driver)
@@ -67,7 +67,7 @@ describe Togls::RuleRepository do
 
   describe "#extract_storage_payload" do
     it 'gets the rule_type_id from rule type repository' do
-      rule = Togls::Rule.new(true, target_type: :foo)
+      rule = Togls::Rule.new(target_type: :foo)
       expect(rule_type_registry).to receive(:get_type_id).with('Togls::Rule')
       subject.extract_storage_payload(rule)
     end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -23,7 +23,7 @@ describe Togls::Rule do
   end
 
   describe '#initialize' do
-    context 'when given intialization data' do
+    context 'when given initialization data' do
       context 'when given target type' do
         it 'assigns the given data to an instance variable' do
           data = double('data')
@@ -56,6 +56,43 @@ describe Togls::Rule do
 
             data = double('data')
             rule = rule_klass.new(data)
+            expect(rule.target_type).to eq(:foo)
+          end
+        end
+      end
+    end
+
+    context 'when not given initialization data' do
+      context 'when given target type' do
+        it 'assigns the data instance variable to nil' do
+          rule = Togls::Rule.new(target_type: :foo)
+          expect(rule.instance_variable_get(:@data)).to be_nil
+        end
+
+        it 'assigns the given target type to an instance variable' do
+          rule = Togls::Rule.new(target_type: :some_target_type)
+          expect(rule.instance_variable_get(:@target_type)).to eq(:some_target_type)
+        end
+      end
+
+      context 'when not given target type' do
+        context 'when rule type did not set target type' do
+          it 'raises target type missing exception' do
+            expect {
+              rule = Togls::Rule.new
+            }.to raise_error(Togls::RuleMissingTargetType)
+          end
+        end
+
+        context 'when rule type did set target type' do
+          it 'return the rule types target type' do
+            rule_klass = Class.new(Togls::Rule) do
+              def self.target_type
+                :foo
+              end
+            end
+
+            rule = rule_klass.new
             expect(rule.target_type).to eq(:foo)
           end
         end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -32,8 +32,7 @@ describe Togls::Rule do
         end
 
         it 'assigns the given target type to an instance variable' do
-          data = double('data')
-          rule = Togls::Rule.new(data, target_type: :some_target_type)
+          rule = Togls::Rule.new(target_type: :some_target_type)
           expect(rule.instance_variable_get(:@target_type)).to eq(:some_target_type)
         end
       end
@@ -42,8 +41,7 @@ describe Togls::Rule do
         context 'when rule type did not set target type' do
           it 'raises target type missing exception' do
             expect {
-              data = double('data')
-              rule = Togls::Rule.new(data)
+              rule = Togls::Rule.new
             }.to raise_error(Togls::RuleMissingTargetType)
           end
         end
@@ -67,7 +65,7 @@ describe Togls::Rule do
 
   describe "#run" do
     it "raises NotImplemented exception" do
-      rule = Togls::Rule.new("test value", target_type: :foo)
+      rule = Togls::Rule.new(target_type: :foo)
       expect { rule.run(double('feature key')) }
         .to raise_error(Togls::NotImplemented)
     end
@@ -98,7 +96,7 @@ describe Togls::Rule do
   describe '#target_type' do
     context 'when the rule instance has a target type' do
       it 'returns the rule instances target type' do
-        rule = Togls::Rule.new('some data', target_type: :hoopty)
+        rule = Togls::Rule.new(target_type: :hoopty)
         expect(rule.target_type).to eq(:hoopty)
       end
     end
@@ -122,14 +120,14 @@ describe Togls::Rule do
   describe '#missing_target_type?' do
     context 'when target type is set' do
       it 'returns false' do
-        rule = Togls::Rule.new(double, target_type: :foo)
+        rule = Togls::Rule.new(target_type: :foo)
         expect(rule.missing_target_type?).to eq(false)
       end
     end
 
     context 'when target type is not set' do
       it 'returns true' do
-        rule = Togls::Rule.new(double, target_type: :hoopty)
+        rule = Togls::Rule.new(target_type: :hoopty)
         rule.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
         expect(rule.missing_target_type?).to eq(true)
       end
@@ -137,7 +135,7 @@ describe Togls::Rule do
 
     context 'when target type is nil' do
       it 'returns true' do
-        rule = Togls::Rule.new(double, target_type: :hoopty)
+        rule = Togls::Rule.new(target_type: :hoopty)
         rule.instance_variable_set(:@target_type, nil)
         expect(rule.missing_target_type?).to eq(true)
       end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -23,38 +23,51 @@ describe Togls::Rule do
   end
 
   describe '#initialize' do
-    context 'when just given intialization data' do
-      it 'assigns the given data to an instance variable' do
-        data = double('data')
-        rule = Togls::Rule.new(data)
-        expect(rule.instance_variable_get(:@data)).to eq(data)
+    context 'when given intialization data' do
+      context 'when given target type' do
+        it 'assigns the given data to an instance variable' do
+          data = double('data')
+          rule = Togls::Rule.new(data, target_type: :foo)
+          expect(rule.instance_variable_get(:@data)).to eq(data)
+        end
+
+        it 'assigns the given target type to an instance variable' do
+          data = double('data')
+          rule = Togls::Rule.new(data, target_type: :some_target_type)
+          expect(rule.instance_variable_get(:@target_type)).to eq(:some_target_type)
+        end
       end
 
-      it 'assigns the target type instance variable to nil' do
-        data = double('data')
-        rule = Togls::Rule.new(data)
-        expect(rule.instance_variable_get(:@target_type)).to eq(Togls::TargetTypes::NOT_SET)
-      end
-    end
+      context 'when not given target type' do
+        context 'when rule type did not set target type' do
+          it 'raises target type missing exception' do
+            expect {
+              data = double('data')
+              rule = Togls::Rule.new(data)
+            }.to raise_error(Togls::RuleMissingTargetType)
+          end
+        end
 
-    context 'when given initialization data and target_type' do
-      it 'assigns the given data to an instance variable' do
-        data = double('data')
-        rule = Togls::Rule.new(data, target_type: :some_target_type)
-        expect(rule.instance_variable_get(:@data)).to eq(data)
-      end
+        context 'when rule type did set target type' do
+          it 'return the rule types target type' do
+            rule_klass = Class.new(Togls::Rule) do
+              def self.target_type
+                :foo
+              end
+            end
 
-      it 'assigns the given target type to an instance variable' do
-        data = double('data')
-        rule = Togls::Rule.new(data, target_type: :some_target_type)
-        expect(rule.instance_variable_get(:@target_type)).to eq(:some_target_type)
+            data = double('data')
+            rule = rule_klass.new(data)
+            expect(rule.target_type).to eq(:foo)
+          end
+        end
       end
     end
   end
 
   describe "#run" do
     it "raises NotImplemented exception" do
-      rule = Togls::Rule.new("test value")
+      rule = Togls::Rule.new("test value", target_type: :foo)
       expect { rule.run(double('feature key')) }
         .to raise_error(Togls::NotImplemented)
     end
@@ -77,7 +90,7 @@ describe Togls::Rule do
 
   describe "#data" do
     it "returns the data it was initially initialized with" do
-      rule = Togls::Rule.new("test value")
+      rule = Togls::Rule.new("test value", target_type: :foo)
       expect(rule.data).to eq("test value")
     end
   end
@@ -91,20 +104,7 @@ describe Togls::Rule do
     end
 
     context 'when the rule instance has NO target type or is NOT_SET' do
-      context 'the class target type is nil' do
-        it 'returns the rule type target type' do
-          rule_klass = Class.new(Togls::Rule) do
-            def self.target_type
-              nil
-            end
-          end
-
-          rule = rule_klass.new('some data')
-          expect(rule.target_type).to eq(Togls::TargetTypes::NOT_SET)
-        end
-      end
-
-      context 'when the class target type is NOT nil' do
+      context 'when the rule type target type is NOT nil' do
         it 'returns the rule type target type' do
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
@@ -115,6 +115,31 @@ describe Togls::Rule do
           rule = rule_klass.new('some data')
           expect(rule.target_type).to eq(:woot_woot)
         end
+      end
+    end
+  end
+
+  describe '#missing_target_type?' do
+    context 'when target type is set' do
+      it 'returns false' do
+        rule = Togls::Rule.new(double, target_type: :foo)
+        expect(rule.missing_target_type?).to eq(false)
+      end
+    end
+
+    context 'when target type is not set' do
+      it 'returns true' do
+        rule = Togls::Rule.new(double, target_type: :hoopty)
+        rule.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
+        expect(rule.missing_target_type?).to eq(true)
+      end
+    end
+
+    context 'when target type is nil' do
+      it 'returns true' do
+        rule = Togls::Rule.new(double, target_type: :hoopty)
+        rule.instance_variable_set(:@target_type, nil)
+        expect(rule.missing_target_type?).to eq(true)
       end
     end
   end

--- a/spec/togls/rules/group_spec.rb
+++ b/spec/togls/rules/group_spec.rb
@@ -22,7 +22,7 @@ describe Togls::Rules::Group do
   describe "#run" do
     context "when the target is included in the list" do
       it "returns true" do
-        group = Togls::Rules::Group.new(["target"])
+        group = Togls::Rules::Group.new(["target"], target_type: :foo)
         expect(group.run(double('feature_key'), "target")).to eq(true)
       end
     end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -67,7 +67,7 @@ describe Togls::Toggle do
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              :hoopty # doing this allow construction, changing it after
+              :hoopty
             end
           end
           rule = rule_klass.new

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -67,10 +67,11 @@ describe Togls::Toggle do
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              Togls::TargetTypes::NOT_SET
+              :hoopty # doing this allow construction, changing it after
             end
           end
           rule = rule_klass.new
+          allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql false
@@ -154,10 +155,11 @@ describe Togls::Toggle do
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              Togls::TargetTypes::NOT_SET
+              :hoopty
             end
           end
           rule = rule_klass.new
+          allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql false
@@ -207,10 +209,11 @@ describe Togls::Toggle do
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              Togls::TargetTypes::NOT_SET
+              :foo
             end
           end
           rule = rule_klass.new
+          allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql false

--- a/spec/togls/toggler_spec.rb
+++ b/spec/togls/toggler_spec.rb
@@ -31,17 +31,15 @@ describe Togls::Toggler do
   describe "#on" do
     context "when the rule is nil" do
       it "creates a new rule" do
-        toggle = subject.instance_variable_get(:@toggle)
-        toggle_repository = subject.instance_variable_get(:@toggle_repository)
         allow(toggle_repository).to receive(:store)
         allow(toggle).to receive(:rule=)
-        expect(Togls::Rules::Boolean).to receive(:new).once
+        expect(Togls::Rules::Boolean).to receive(:new).once.and_return(Togls::Rules::Boolean.new)
         subject.on
       end
     end
 
     it "sets the toggle's rule to the new rule" do
-      rule = double('rule')
+      rule = Togls::Rules::Boolean.new
       toggle_repository = subject.instance_variable_get(:@toggle_repository)
       allow(toggle_repository).to receive(:store)
       allow(Togls::Rules::Boolean).to receive(:new).and_return(rule)


### PR DESCRIPTION
Why you made the change:

I did this so that it will raise an exception when constructing a rule that
doesn't have a target type set.