### PR TITLE
Add logging for when rules and features are in erroneous state

### DIFF
--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -23,20 +23,24 @@ module Togls
 
     # feature target type | rule target type | match? | notes
     # -------------------------------------------------------
-    # NOT_SET             | NOT_SET          | false  | broken - shouldn't happen
     # NOT_SET             | NONE             | true   |
-    # NOT_SET             | something (foo)  | false  | broken - shouldn't happen
     # NONE                | NONE             | true   |
-    # NONE                | something (foo)  | false  |
-    # NONE                | NOT_SET          | false  | broken - shouldn't happen
     # something (foo)     | NONE             | true   |
-    # something (foo)     | something (foo)  | true   |
+    # NOT_SET             | NOT_SET          | false  | broken - shouldn't happen
+    # NONE                | NOT_SET          | false  | broken - shouldn't happen
     # something (foo)     | NOT_SET          | false  | broken - shouldn't happen
+    # NOT_SET             | something (foo)  | false  | broken - shouldn't happen
+    # NONE                | something (foo)  | false  |
+    # something (foo)     | something (foo)  | true   |
     # something (foo)     | something (bar)  | false  |
     def target_matches?(rule)
       if rule.target_type == Togls::TargetTypes::NONE
         return true
       elsif rule.target_type == Togls::TargetTypes::NOT_SET
+        Togls.logger.warn "Rule (id: #{rule.id}) cannot have target type of :not_set"
+        return false
+      elsif @feature.target_type == Togls::TargetTypes::NOT_SET
+        Togls.logger.warn "Feature (key: #{feature.key}) cannot have target type of :not_set when rule (id: #{rule.id}) specifies a target type (target_type: #{rule.target_type}"
         return false
       elsif rule.target_type == @feature.target_type
         return true

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -61,7 +61,7 @@ describe Togls::Toggle do
   describe '#target_matches?' do
     context 'when the features target type is not set' do
       context 'when the rules target type is not set' do
-        it 'returns false' do
+        it 'logs that the rule is broken' do
           feature = Togls::Feature.new('some name', 'some desc')
           toggle = Togls::Toggle.new(feature)
 
@@ -73,6 +73,21 @@ describe Togls::Toggle do
           rule = rule_klass.new
           allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
+          expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
+          toggle.target_matches?(rule)
+        end
+
+        it 'returns false' do
+          allow(Togls.logger).to receive(:warn)
+          feature = Togls::Feature.new('some name', 'some desc')
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NOT_SET
+            end
+          end
+          rule = rule_klass.new
           result = toggle.target_matches?(rule)
           expect(result).to eql false
         end
@@ -96,7 +111,23 @@ describe Togls::Toggle do
       end
 
       context 'when the rules target type is specified' do
+        it 'logs that the feature is broken' do
+          feature = Togls::Feature.new('some name', 'some desc')
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              :foo
+            end
+          end
+          rule = rule_klass.new
+
+          expect(Togls.logger).to receive(:warn).with("Feature (key: #{feature.key}) cannot have target type of :not_set when rule (id: #{rule.id}) specifies a target type (target_type: #{rule.target_type}")
+          toggle.target_matches?(rule)
+        end
+
         it 'returns false' do
+          allow(Togls.logger).to receive(:warn)
           feature = Togls::Feature.new('some name', 'some desc')
           toggle = Togls::Toggle.new(feature)
 
@@ -149,7 +180,23 @@ describe Togls::Toggle do
       end
 
       context 'when the rules target type is not set' do
+        it 'logs that the rule is broken' do
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NOT_SET
+            end
+          end
+          rule = rule_klass.new
+
+          expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
+          toggle.target_matches?(rule)
+        end
+
         it 'returns false' do
+          allow(Togls.logger).to receive(:warn)
           feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
           toggle = Togls::Toggle.new(feature)
 
@@ -203,7 +250,23 @@ describe Togls::Toggle do
       end
 
       context 'when the rules target type is not set' do
+        it 'logs that the rule is broken' do
+          feature = Togls::Feature.new('some name', 'some desc', :foo)
+          toggle = Togls::Toggle.new(feature)
+
+          rule_klass = Class.new(Togls::Rule) do
+            def self.target_type
+              Togls::TargetTypes::NOT_SET
+            end
+          end
+          rule = rule_klass.new
+
+          expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
+          toggle.target_matches?(rule)
+        end
+
         it 'returns false' do
+          allow(Togls.logger).to receive(:warn)
           feature = Togls::Feature.new('some name', 'some desc', :foo)
           toggle = Togls::Toggle.new(feature)
 

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -84,10 +84,12 @@ describe Togls::Toggle do
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              Togls::TargetTypes::NOT_SET
+              :hoopty
             end
           end
           rule = rule_klass.new
+          allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
+
           result = toggle.target_matches?(rule)
           expect(result).to eql false
         end
@@ -186,10 +188,11 @@ describe Togls::Toggle do
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              Togls::TargetTypes::NOT_SET
+              :foo
             end
           end
           rule = rule_klass.new
+          allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
           toggle.target_matches?(rule)
@@ -256,10 +259,11 @@ describe Togls::Toggle do
 
           rule_klass = Class.new(Togls::Rule) do
             def self.target_type
-              Togls::TargetTypes::NOT_SET
+              :foo
             end
           end
           rule = rule_klass.new
+          allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
           toggle.target_matches?(rule)


### PR DESCRIPTION
I did this because there are some target type states in rules and features
that should never ever happen. If they happen we want to log it so that you
can find and correct the problem.

Relates to [this issue](https://github.com/codebreakdown/togls/issues/69)