### PR TITLE
Add default feature target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Added`: setting a default feature target type
+  ([#69](https://github.com/codebreakdown/togls/issues/69))
 * `Added`: rule instance target types and switch type checking over
   ([#67](https://github.com/codebreakdown/togls/issues/67))
 * `Added`: optional target types, and target type checking

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -26,6 +26,7 @@ require 'togls/rule'
 require 'togls/rules'
 require 'logger'
 require 'togls/feature_toggle_registry_manager'
+require 'togls/default_feature_target_type_manager'
 
 # Togls
 #
@@ -33,4 +34,5 @@ require 'togls/feature_toggle_registry_manager'
 # the namespace the DSL is exposed under.
 module Togls
   include FeatureToggleRegistryManager
+  include DefaultFeatureTargetTypeManager
 end

--- a/lib/togls/default_feature_target_type_manager.rb
+++ b/lib/togls/default_feature_target_type_manager.rb
@@ -1,0 +1,25 @@
+module Togls
+  module DefaultFeatureTargetTypeManager
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def default_feature_target_type(target_type = nil)
+        if target_type
+          if @default_feature_target_type
+            raise Togls::DefaultFeatureTargetTypeAlreadySet, 'the default feature target type has already been set'
+          else
+            @default_feature_target_type = target_type
+          end
+        else
+          if @default_feature_target_type
+            return @default_feature_target_type
+          else
+            return Togls::TargetTypes::NOT_SET
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -8,4 +8,6 @@ module Togls
   class RuleTypeAlreadyDefined < Error; end
   class RuleFeatureTargetTypeMismatch < Error; end
   class RuleMissingTargetType < Error; end
+  class DefaultFeatureTargetTypeAlreadySet < Error; end
+  class FeatureMissingTargetType < Error; end
 end

--- a/lib/togls/feature.rb
+++ b/lib/togls/feature.rb
@@ -6,10 +6,11 @@ module Togls
   class Feature
     attr_reader :key, :description
 
-    def initialize(key, description, target_type = Togls::TargetTypes::NOT_SET)
+    def initialize(key, description, target_type)
       @key = key.to_s
       @description = description
       @target_type = target_type
+      raise Togls::FeatureMissingTargetType, "Feature '#{self.key}' is missing a required target type" if self.missing_target_type?
     end
 
     def target_type
@@ -19,6 +20,11 @@ module Togls
 
     def id
       @key
+    end
+
+    def missing_target_type?
+      return false if target_type && (target_type != Togls::TargetTypes::NOT_SET)
+      return true
     end
   end
 end

--- a/lib/togls/null_toggle.rb
+++ b/lib/togls/null_toggle.rb
@@ -5,7 +5,7 @@ module Togls
   # toggle found when requested to be retreived through a Toggle Repository.
   class NullToggle < Togls::Toggle
     def initialize
-      feature = Togls::Feature.new('null', 'the official null feature')
+      feature = Togls::Feature.new('null', 'the official null feature', Togls::TargetTypes::NONE)
       super(feature)
     end
 

--- a/lib/togls/toggle_registry.rb
+++ b/lib/togls/toggle_registry.rb
@@ -16,7 +16,7 @@ module Togls
       self
     end
 
-    def feature(key, desc, target_type: Togls::TargetTypes::NOT_SET)
+    def feature(key, desc, target_type: Togls.default_feature_target_type)
       verify_uniqueness_of_feature(key)
       feature = Togls::Feature.new(key, desc, target_type)
       toggle = Togls::Toggle.new(feature)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,12 @@ RSpec.configure do |c|
     Togls.instance_variable_set(:@rule_type_repository, nil)
     Togls.instance_variable_set(:@rule_type_registry, nil)
   end
+
+  c.around(:each) do |example|
+    save_default_feature_target_type = Togls.default_feature_target_type
+    # Togls.instance_variable_set(:@default_feature_target_type, :test_target_type)
+    Togls.instance_variable_set(:@default_feature_target_type, nil)
+    example.run
+    Togls.instance_variable_set(:@default_feature_target_type, save_default_feature_target_type)
+  end
 end

--- a/spec/togls/default_feature_target_type_manager_spec.rb
+++ b/spec/togls/default_feature_target_type_manager_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Togls::DefaultFeatureTargetTypeManager do
         end
       end
 
-      context 'when default feature target type has been set' do
+      context 'when default feature target type has previously been set' do
         it 'raises an exception' do
           klass = Class.new do
             include Togls::DefaultFeatureTargetTypeManager

--- a/spec/togls/default_feature_target_type_manager_spec.rb
+++ b/spec/togls/default_feature_target_type_manager_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe Togls::DefaultFeatureTargetTypeManager do
+  describe '#default_feature_target_type' do
+    describe 'setting the default feature target type' do
+      context 'when default feature target type has not been set' do
+        it 'sets the default feature target type' do
+          klass = Class.new do
+            include Togls::DefaultFeatureTargetTypeManager
+          end
+
+          klass.default_feature_target_type Togls::TargetTypes::NONE
+          expect(klass.instance_variable_get(:@default_feature_target_type)).to eq(Togls::TargetTypes::NONE)
+        end
+      end
+
+      context 'when default feature target type has been set' do
+        it 'raises an exception' do
+          klass = Class.new do
+            include Togls::DefaultFeatureTargetTypeManager
+          end
+
+          klass.default_feature_target_type Togls::TargetTypes::NONE
+          expect {
+            klass.default_feature_target_type Togls::TargetTypes::NONE
+          }.to raise_error(Togls::DefaultFeatureTargetTypeAlreadySet)
+        end
+      end
+    end
+
+    describe 'getting the default feature target type' do
+      context 'when already set' do
+        it 'gets the default feature target type' do
+          klass = Class.new do
+            include Togls::DefaultFeatureTargetTypeManager
+          end
+
+          klass.default_feature_target_type Togls::TargetTypes::NONE
+          expect(klass.default_feature_target_type).to eq(Togls::TargetTypes::NONE)
+        end
+      end
+
+      context 'when not already set' do
+        it 'returns NOT_SET' do
+          klass = Class.new do
+            include Togls::DefaultFeatureTargetTypeManager
+          end
+
+          expect(klass.default_feature_target_type).to eq(Togls::TargetTypes::NOT_SET)
+        end
+      end
+    end
+  end
+end

--- a/spec/togls/feature_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/feature_repository_drivers/in_memory_driver_spec.rb
@@ -14,7 +14,7 @@ describe Togls::FeatureRepositoryDrivers::InMemoryDriver do
 
   describe "storing and retrieving" do
     it "saves and retrieves the storage payload" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :foo)
       subject.store(feature.id, { "key" => feature.key, "description" => feature.description })
       expect(subject.get(feature.id)).to eq({ "key" => feature.key, "description" => feature.description })
     end

--- a/spec/togls/feature_repository_spec.rb
+++ b/spec/togls/feature_repository_spec.rb
@@ -34,20 +34,20 @@ describe Togls::FeatureRepository do
 
   describe "#store" do
     it "extracts the feature data" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       expect(subject).to receive(:extract_feature_data).with(feature)
       allow(driver).to receive(:store)
       subject.store(feature)
     end
 
     it "iterate over each driver" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       expect(subject.instance_variable_get(:@drivers)).to receive(:each)
       subject.store(feature)
     end
 
     it "store the toggle in each driver" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       feature_data = double('feature data')
       allow(subject).to receive(:extract_feature_data).and_return(feature_data)
       allow(subject.instance_variable_get(:@drivers)).to receive(:each).and_yield(driver)

--- a/spec/togls/feature_spec.rb
+++ b/spec/togls/feature_spec.rb
@@ -16,11 +16,11 @@ describe Togls::Feature do
       expect(subject.target_type).to eq(:foo_target_type)
     end
 
-    context 'when constructed without a target_type' do
-      subject { Togls::Feature.new(:key, 'some description') }
-
-      it 'assigns the target_type to be not set' do
-        expect(subject.target_type).to eq(Togls::TargetTypes::NOT_SET)
+    context 'when constructed target_type NOT set' do
+      it 'raises exception saying feature missing target type' do
+        expect {
+          Togls::Feature.new(:key, 'some description', Togls::TargetTypes::NOT_SET)
+        }.to raise_error(Togls::FeatureMissingTargetType)
       end
     end
   end
@@ -39,9 +39,10 @@ describe Togls::Feature do
     end
 
     context 'when the target type is nil' do
-      subject { Togls::Feature.new(:key, 'some description', nil) }
+      subject { Togls::Feature.new(:key, 'some description', :oeueou) }
 
       it 'returns a not set target type' do
+        subject.instance_variable_set(:@target_type, nil)
         expect(subject.target_type).to eq(Togls::TargetTypes::NOT_SET)
       end
     end
@@ -56,6 +57,31 @@ describe Togls::Feature do
   describe "#id" do
     it "returns the key of the feature" do
       expect(subject.id).to eq("key")
+    end
+  end
+
+  describe '#missing_target_type?' do
+    context 'when target type is set' do
+      it 'returns false' do
+        feature = Togls::Feature.new(:foo, 'desc', :hoopty)
+        expect(feature.missing_target_type?).to eq(false)
+      end
+    end
+
+    context 'when target type is not set' do
+      it 'returns true' do
+        feature = Togls::Feature.new(:foo, 'desc', :faoeu)
+        feature.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
+        expect(feature.missing_target_type?).to eq(true)
+      end
+    end
+
+    context 'when target type is nil' do
+      it 'returns true' do
+        feature = Togls::Feature.new(:foo, 'desc', :faoeu)
+        feature.instance_variable_set(:@target_type, nil)
+        expect(feature.missing_target_type?).to eq(true)
+      end
     end
   end
 end

--- a/spec/togls/null_toggle_spec.rb
+++ b/spec/togls/null_toggle_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Togls::NullToggle do
   describe "#initialize" do
     it "constructs a null feature" do
-      expect(Togls::Feature).to receive(:new).with("null", "the official null feature")
+      expect(Togls::Feature).to receive(:new).with("null", "the official null feature", Togls::TargetTypes::NONE)
       subject
     end
   end

--- a/spec/togls/toggle_registry_spec.rb
+++ b/spec/togls/toggle_registry_spec.rb
@@ -48,6 +48,7 @@ describe Togls::ToggleRegistry do
 
   describe "#feature" do
     it "verifies that the feature is unique" do
+      Togls.default_feature_target_type :hoopty
       expect(subject).to receive(:verify_uniqueness_of_feature).with(:some_key)
       subject.feature(:some_key, "description")
     end
@@ -82,6 +83,7 @@ describe Togls::ToggleRegistry do
     end
 
     it "constructs a toggler" do
+      Togls.default_feature_target_type :hoopty
       key = "some_key"
       desc = double('feature desc')
       toggle_repository = subject.instance_variable_get(:@toggle_repository)
@@ -93,6 +95,7 @@ describe Togls::ToggleRegistry do
     end
 
     it "returns the created toggler" do
+      Togls.default_feature_target_type :hoopty
       key = "some_key"
       desc = double('feature desc')
       toggle = double('toggle').as_null_object

--- a/spec/togls/toggle_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/toggle_repository_drivers/in_memory_driver_spec.rb
@@ -14,7 +14,7 @@ describe Togls::ToggleRepositoryDrivers::InMemoryDriver do
 
   describe "storing and retrieving" do
     it "saves the storage payload and retrieves it" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       toggle = Togls::Toggle.new(feature)
       toggle_data = { 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id }
       subject.store(toggle.id, toggle_data)
@@ -30,7 +30,7 @@ describe Togls::ToggleRepositoryDrivers::InMemoryDriver do
 
   describe "#all" do
     it "returns the collection of toggles" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       toggle = Togls::Toggle.new(feature)
       toggle_data = { 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id }
       subject.store(toggle.id, toggle_data)

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -76,7 +76,7 @@ describe Togls::ToggleRepository do
     end
 
     it "gets the storage payload" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       toggle = Togls::Toggle.new(feature)
       allow(subject.instance_variable_get(:@feature_repository)).to receive(:store)
       allow(subject.instance_variable_get(:@rule_repository)).to receive(:store)
@@ -113,7 +113,7 @@ describe Togls::ToggleRepository do
 
   describe "#extract_storage_payload" do
     it "returns the feature's extracted storage payload" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc")
+      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       toggle = Togls::Toggle.new(feature)
       expect(subject.extract_storage_payload(toggle))
         .to eq({ "feature_id" => "some_feature_key", "rule_id" => "4e4b466b49e148b5a58de1d666ca7c87c7765301" })

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -62,7 +62,8 @@ describe Togls::Toggle do
     context 'when the features target type is not set' do
       context 'when the rules target type is not set' do
         it 'logs that the rule is broken' do
-          feature = Togls::Feature.new('some name', 'some desc')
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          feature.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do
@@ -79,7 +80,8 @@ describe Togls::Toggle do
 
         it 'returns false' do
           allow(Togls.logger).to receive(:warn)
-          feature = Togls::Feature.new('some name', 'some desc')
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          feature.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do
@@ -97,7 +99,8 @@ describe Togls::Toggle do
 
       context 'when the rules target type is set to none' do
         it 'returns true' do
-          feature = Togls::Feature.new('some name', 'some desc')
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          feature.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do
@@ -114,7 +117,8 @@ describe Togls::Toggle do
 
       context 'when the rules target type is specified' do
         it 'logs that the feature is broken' do
-          feature = Togls::Feature.new('some name', 'some desc')
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          feature.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do
@@ -130,7 +134,8 @@ describe Togls::Toggle do
 
         it 'returns false' do
           allow(Togls.logger).to receive(:warn)
-          feature = Togls::Feature.new('some name', 'some desc')
+          feature = Togls::Feature.new('some name', 'some desc', Togls::TargetTypes::NONE)
+          feature.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
           toggle = Togls::Toggle.new(feature)
 
           rule_klass = Class.new(Togls::Rule) do


### PR DESCRIPTION
Why you made the change:

I did this so that the DSL could still be the clean simple dsl we like in the
majority of cases. I also made feature require target_type as an argument to
construction similar to how we did with rule previously.