### PR TITLE
Feature validates argument during evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Added`: validation of targets against feature target_type contract
+  ([#78](https://github.com/codebreakdown/togls/issues/78))
 * `Added`: setting a default feature target type
   ([#69](https://github.com/codebreakdown/togls/issues/69))
 * `Added`: logging for target type mismatches/erroneous states

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -10,4 +10,6 @@ module Togls
   class RuleMissingTargetType < Error; end
   class DefaultFeatureTargetTypeAlreadySet < Error; end
   class FeatureMissingTargetType < Error; end
+  class EvaluationTargetMissing < Error; end
+  class UnexpectedEvaluationTarget < Error; end
 end

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -49,11 +49,30 @@ module Togls
       end
     end
 
+    # feature.target_type | target.nil? | valid target
+    # NONE                | false       | FALSE - EXCEPTION
+    # :foo                | true        | FALSE - EXCEPTION
+    # NONE                | true        | true
+    # :foo                | false       | true
+    # NOT_SET             | ignored     | true - broken
+    def validate_target(target)
+      is_explicit_target_type = @feature.target_type != Togls::TargetTypes::NONE &&
+        @feature.target_type != Togls::TargetTypes::NOT_SET
+      if @feature.target_type == Togls::TargetTypes::NONE && target
+        raise Togls::UnexpectedEvaluationTarget
+      elsif is_explicit_target_type && target.nil?
+        raise Togls::EvaluationTargetMissing
+      end
+      # Is valid
+    end
+
     def on?(target = nil)
+      validate_target(target)
       @rule.run(@feature.key, target)
     end
 
     def off?(target = nil)
+      validate_target(target)
       !@rule.run(@feature.key, target)
     end
   end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -346,29 +346,27 @@ describe Togls::Toggle do
     end
 
     context 'when the feature target type contract specifies a target type' do
-      context 'when the rule target type expects a target' do
-        context 'when the target is not nil' do
-          it 'succeeds at validating' do
-            feature = Togls::Feature.new(:name, 'desc', :foo)
-            rule = Togls::Rule.new(target_type: :foo)
-            toggle = Togls::Toggle.new(feature)
-            toggle.rule = rule
-            expect {
-              toggle.validate_target('asdf')
-            }.not_to raise_error
-          end
+      context 'when the target is not nil' do
+        it 'succeeds at validating' do
+          feature = Togls::Feature.new(:name, 'desc', :foo)
+          rule = Togls::Rule.new(target_type: :foo)
+          toggle = Togls::Toggle.new(feature)
+          toggle.rule = rule
+          expect {
+            toggle.validate_target('asdf')
+          }.not_to raise_error
         end
+      end
 
-        context 'when the target is nil' do
-          it 'raises an exception' do
-            feature = Togls::Feature.new(:name, 'desc', :foo)
-            rule = Togls::Rule.new(target_type: :foo)
-            toggle = Togls::Toggle.new(feature)
-            toggle.rule = rule
-            expect {
-              toggle.validate_target(nil)
-            }.to raise_error Togls::EvaluationTargetMissing
-          end
+      context 'when the target is nil' do
+        it 'raises an exception' do
+          feature = Togls::Feature.new(:name, 'desc', :foo)
+          rule = Togls::Rule.new(target_type: :foo)
+          toggle = Togls::Toggle.new(feature)
+          toggle.rule = rule
+          expect {
+            toggle.validate_target(nil)
+          }.to raise_error Togls::EvaluationTargetMissing
         end
       end
     end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -311,11 +311,82 @@ describe Togls::Toggle do
     end
   end
 
+  describe "#validate_target" do
+    context 'when the feature target type contract is NONE' do
+      context 'when the target is not nil' do
+        it 'raises an exception' do
+          feature = Togls::Feature.new(:foo, 'desc', Togls::TargetTypes::NONE)
+          toggle = Togls::Toggle.new(feature)
+          expect {
+            toggle.validate_target('asdf')
+          }.to raise_error Togls::UnexpectedEvaluationTarget
+        end
+      end
+
+      context 'when the target is nil' do
+        it 'succeeds at validating' do
+          feature = Togls::Feature.new(:foo, 'desc', Togls::TargetTypes::NONE)
+          toggle = Togls::Toggle.new(feature)
+          expect {
+            toggle.validate_target(nil)
+          }.not_to raise_error
+        end
+      end
+    end
+
+    context 'when the feature target type contract is NOT_SET' do
+      it 'succeeds at validating' do
+        feature = Togls::Feature.new(:foo, 'desc', :foo)
+        feature.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
+        toggle = Togls::Toggle.new(feature)
+        expect {
+          toggle.validate_target('asdf')
+        }.not_to raise_error
+      end
+    end
+
+    context 'when the feature target type contract specifies a target type' do
+      context 'when the rule target type expects a target' do
+        context 'when the target is not nil' do
+          it 'succeeds at validating' do
+            feature = Togls::Feature.new(:name, 'desc', :foo)
+            rule = Togls::Rule.new(target_type: :foo)
+            toggle = Togls::Toggle.new(feature)
+            toggle.rule = rule
+            expect {
+              toggle.validate_target('asdf')
+            }.not_to raise_error
+          end
+        end
+
+        context 'when the target is nil' do
+          it 'raises an exception' do
+            feature = Togls::Feature.new(:name, 'desc', :foo)
+            rule = Togls::Rule.new(target_type: :foo)
+            toggle = Togls::Toggle.new(feature)
+            toggle.rule = rule
+            expect {
+              toggle.validate_target(nil)
+            }.to raise_error Togls::EvaluationTargetMissing
+          end
+        end
+      end
+    end
+  end
+
   describe "#on?" do
+    it 'validates target against feature contract' do
+      target = double('target')
+      allow(feature).to receive(:key).and_return("key")
+      expect(subject).to receive(:validate_target).with(target)
+      subject.on?(target)
+    end
+
     it "runs the associated rule" do
       rule = double('rule')
       target = double('target')
       subject.instance_variable_set(:@rule, rule)
+      allow(subject).to receive(:validate_target).with(target)
       allow(feature).to receive(:key).and_return("key")
       expect(rule).to receive(:run).with(subject.feature.key, target)
       subject.on?(target)
@@ -326,6 +397,7 @@ describe Togls::Toggle do
       target = double('target')
       result = double('result')
       subject.instance_variable_set(:@rule, rule)
+      allow(subject).to receive(:validate_target).with(target)
       allow(feature).to receive(:key).and_return("key")
       allow(rule).to receive(:run).and_return(result)
       expect(subject.on?(target)).to eq(result)
@@ -333,10 +405,18 @@ describe Togls::Toggle do
   end
 
   describe "#off?" do
+    it 'validates target against feature contract' do
+      target = double('target')
+      allow(feature).to receive(:key).and_return("key")
+      expect(subject).to receive(:validate_target).with(target)
+      subject.off?(target)
+    end
+
     it "runs the associated rule" do
       rule = double('rule')
       target = double('target')
       subject.instance_variable_set(:@rule, rule)
+      allow(subject).to receive(:validate_target).with(target)
       allow(feature).to receive(:key).and_return("key")
       expect(rule).to receive(:run).with(subject.feature.key, target)
       subject.off?(target)
@@ -347,6 +427,7 @@ describe Togls::Toggle do
       target = double('target')
       result = false
       subject.instance_variable_set(:@rule, rule)
+      allow(subject).to receive(:validate_target).with(target)
       allow(feature).to receive(:key).and_return("key")
       allow(rule).to receive(:run).and_return(result)
       expect(subject.off?(target)).to eq(true)

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -489,7 +489,7 @@ describe "Togl" do
       end
 
       context 'when the feature evaluation does NOT send a target' do
-        it 'can be corredtly evaluated' do
+        it 'can be correctly evaluated' do
           Togls.release do
             feature(:foo, 'desc', target_type: Togls::TargetTypes::NONE).on
           end


### PR DESCRIPTION
I did this so that when a feature is evaluated in code developers can be
informed before deployment when there is a feature target type contract
breach.

This compares the evaluation target against the expectations of the features
target type contract and raises appropriate exceptions in the contract breach
scenarios.

Relates to #78