### PR TITLE
Fix null toggle null feature target type

### DIFF
--- a/lib/togls/null_toggle.rb
+++ b/lib/togls/null_toggle.rb
@@ -5,7 +5,7 @@ module Togls
   # toggle found when requested to be retreived through a Toggle Repository.
   class NullToggle < Togls::Toggle
     def initialize
-      feature = Togls::Feature.new('null', 'the official null feature', Togls::TargetTypes::NONE)
+      feature = Togls::Feature.new('null', 'the official null feature', Togls::TargetTypes::EITHER)
       super(feature)
     end
 

--- a/lib/togls/target_types.rb
+++ b/lib/togls/target_types.rb
@@ -1,6 +1,9 @@
 module Togls
   module TargetTypes
+    # one (explicit one), none (explicity none), either (explicit for null
+    # toggle case), not set (original explicit hasn't been set yet)
     NONE = :none
     NOT_SET = :not_set
+    EITHER = :either
   end
 end

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -55,6 +55,8 @@ module Togls
     # NONE                | true        | true
     # :foo                | false       | true
     # NOT_SET             | ignored     | true - broken
+    # EITHER              | true        | true
+    # EITHER              | false       | true
     def validate_target(target)
       is_explicit_target_type = @feature.target_type != Togls::TargetTypes::NONE &&
         @feature.target_type != Togls::TargetTypes::NOT_SET &&

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -57,7 +57,8 @@ module Togls
     # NOT_SET             | ignored     | true - broken
     def validate_target(target)
       is_explicit_target_type = @feature.target_type != Togls::TargetTypes::NONE &&
-        @feature.target_type != Togls::TargetTypes::NOT_SET
+        @feature.target_type != Togls::TargetTypes::NOT_SET &&
+        @feature.target_type != Togls::TargetTypes::EITHER
       if @feature.target_type == Togls::TargetTypes::NONE && target
         raise Togls::UnexpectedEvaluationTarget
       elsif is_explicit_target_type && target.nil?

--- a/spec/togls/null_toggle_spec.rb
+++ b/spec/togls/null_toggle_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Togls::NullToggle do
   describe "#initialize" do
     it "constructs a null feature" do
-      expect(Togls::Feature).to receive(:new).with("null", "the official null feature", Togls::TargetTypes::NONE)
+      expect(Togls::Feature).to receive(:new).with("null", "the official null feature", Togls::TargetTypes::EITHER)
       subject
     end
   end

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -345,6 +345,17 @@ describe Togls::Toggle do
       end
     end
 
+    context 'when the feature target type contract is EITHER' do
+      it 'succeeds at validating' do
+        feature = Togls::Feature.new(:foo, 'desc', :foo)
+        feature.instance_variable_set(:@target_type, Togls::TargetTypes::EITHER)
+        toggle = Togls::Toggle.new(feature)
+        expect {
+          toggle.validate_target('asdf')
+        }.not_to raise_error
+      end
+    end
+
     context 'when the feature target type contract specifies a target type' do
       context 'when the target is not nil' do
         it 'succeeds at validating' do

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -346,13 +346,26 @@ describe Togls::Toggle do
     end
 
     context 'when the feature target type contract is EITHER' do
-      it 'succeeds at validating' do
-        feature = Togls::Feature.new(:foo, 'desc', :foo)
-        feature.instance_variable_set(:@target_type, Togls::TargetTypes::EITHER)
-        toggle = Togls::Toggle.new(feature)
-        expect {
-          toggle.validate_target('asdf')
-        }.not_to raise_error
+      context 'when the target is not nil' do
+        it 'succeeds at validating' do
+          feature = Togls::Feature.new(:foo, 'desc', :foo)
+          feature.instance_variable_set(:@target_type, Togls::TargetTypes::EITHER)
+          toggle = Togls::Toggle.new(feature)
+          expect {
+            toggle.validate_target('asdf')
+          }.not_to raise_error
+        end
+      end
+
+      context 'when the target is nil' do
+        it 'succeeds at validating' do
+          feature = Togls::Feature.new(:foo, 'desc', :foo)
+          feature.instance_variable_set(:@target_type, Togls::TargetTypes::EITHER)
+          toggle = Togls::Toggle.new(feature)
+          expect {
+            toggle.validate_target(nil)
+          }.not_to raise_error
+        end
       end
     end
 

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -486,6 +486,19 @@ describe "Togl" do
             Togls.feature(:foo).off?(3)
           }.to raise_error Togls::UnexpectedEvaluationTarget
         end
+
+        context 'when the evaluated feature is not defined' do
+          it 'defaults to false' do
+            # null toggle used in this case has a null feature which has a
+            # target_type of NONE at the moment
+            allow(Togls.logger).to receive(:warn)
+            Togls.release do
+              feature(:test, "some human readable description", target_type: :hoopty).on
+            end
+
+            expect(Togls.feature(:not_defined).on?('aoeuoeau')).to eq(false)
+          end
+        end
       end
 
       context 'when the feature evaluation does NOT send a target' do

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -489,8 +489,6 @@ describe "Togl" do
 
         context 'when the evaluated feature is not defined' do
           it 'defaults to false' do
-            # null toggle used in this case has a null feature which has a
-            # target_type of NONE at the moment
             allow(Togls.logger).to receive(:warn)
             Togls.release do
               feature(:test, "some human readable description", target_type: :hoopty).on


### PR DESCRIPTION
The goal of this was to fix the NullToggle behavior with the new type checking we have added so that it behaves as it did before. Which is to evaluate to false when dealing with a null toggle.