### PR TITLE
Handle exceptions during reconstitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Added`: Feature repository response validation
 * `Added`: validation of targets against feature target_type contract
   ([#78](https://github.com/codebreakdown/togls/issues/78))
 * `Added`: setting a default feature target type

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -12,4 +12,5 @@ module Togls
   class FeatureMissingTargetType < Error; end
   class EvaluationTargetMissing < Error; end
   class UnexpectedEvaluationTarget < Error; end
+  class RepositoryFeatureDataInvalid < Error; end
 end

--- a/lib/togls/errors.rb
+++ b/lib/togls/errors.rb
@@ -13,4 +13,5 @@ module Togls
   class EvaluationTargetMissing < Error; end
   class UnexpectedEvaluationTarget < Error; end
   class RepositoryFeatureDataInvalid < Error; end
+  class RepositoryRuleDataInvalid < Error; end
 end

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -41,11 +41,11 @@ module Togls
 
     def get(feature_id)
       feature_data = fetch_feature_data(feature_id)
+      validate_feature_data(feature_data)
       reconstitute_feature(feature_data)
     end
 
     def reconstitute_feature(feature_data)
-      validate_feature_data(feature_data)
       Togls::Feature.new(feature_data['key'],
                          feature_data['description'],
                          feature_data['target_type'].to_sym)

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -52,10 +52,21 @@ module Togls
     end
 
     def validate_feature_data(feature_data)
-      raise Togls::RepositoryFeatureDataInvalid, "None of the feature repository drivers claim to have the feature" if feature_data.nil?
+      if feature_data.nil?
+        Togls.logger.debug("None of the feature repository drivers claim to have the feature")
+        raise Togls::RepositoryFeatureDataInvalid, "None of the feature repository drivers claim to have the feature"
+      end
+
       ['key', 'description', 'target_type'].each do |k|
-        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that is missing the '#{k}'" unless feature_data.has_key? k
-        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data with '#{k}' not being a string" unless feature_data[k].is_a?(String)
+        if !feature_data.has_key? k
+          Togls.logger.debug("One of the feature repository drivers returned feature data that is missing the '#{k}'")
+          raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that is missing the '#{k}'"
+        end
+
+        if !feature_data[k].is_a?(String)
+          Togls.logger.debug("One of the feature repository drivers returned feature data with '#{k}' not being a string")
+          raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data with '#{k}' not being a string"
+        end
       end
     end
   end

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -45,13 +45,17 @@ module Togls
     end
 
     def reconstitute_feature(feature_data)
-      if feature_data['target_type'].nil?
-        Togls::Feature.new(feature_data['key'],
-                           feature_data['description'])
-      else
-        Togls::Feature.new(feature_data['key'],
-                           feature_data['description'],
-                           feature_data['target_type'].to_sym)
+      validate_feature_data(feature_data)
+      Togls::Feature.new(feature_data['key'],
+                         feature_data['description'],
+                         feature_data['target_type'].to_sym)
+    end
+
+    def validate_feature_data(feature_data)
+      raise Togls::RepositoryFeatureDataInvalid, "None of the feature repository drivers claim to have the feature" if feature_data.nil?
+      keys = ['key', 'description', 'target_type'].each do |k|
+        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that is missing the '#{k}'" if !feature_data.has_key? k
+        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that with '#{k}' not being a string" if !feature_data[k].is_a?(String)
       end
     end
   end

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -53,7 +53,7 @@ module Togls
 
     def validate_feature_data(feature_data)
       raise Togls::RepositoryFeatureDataInvalid, "None of the feature repository drivers claim to have the feature" if feature_data.nil?
-      keys = ['key', 'description', 'target_type'].each do |k|
+      ['key', 'description', 'target_type'].each do |k|
         raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that is missing the '#{k}'" unless feature_data.has_key? k
         raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data with '#{k}' not being a string" unless feature_data[k].is_a?(String)
       end

--- a/lib/togls/feature_repository.rb
+++ b/lib/togls/feature_repository.rb
@@ -54,8 +54,8 @@ module Togls
     def validate_feature_data(feature_data)
       raise Togls::RepositoryFeatureDataInvalid, "None of the feature repository drivers claim to have the feature" if feature_data.nil?
       keys = ['key', 'description', 'target_type'].each do |k|
-        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that is missing the '#{k}'" if !feature_data.has_key? k
-        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that with '#{k}' not being a string" if !feature_data[k].is_a?(String)
+        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data that is missing the '#{k}'" unless feature_data.has_key? k
+        raise Togls::RepositoryFeatureDataInvalid, "One of the feature repository drivers returned feature data with '#{k}' not being a string" unless feature_data[k].is_a?(String)
       end
     end
   end

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -47,14 +47,23 @@ module Togls
     end
 
     def validate_rule_data(rule_data)
-      raise Togls::RepositoryRuleDataInvalid, "None of the rule repository drivers claim to have the rule" if rule_data.nil?
+      if rule_data.nil?
+        Togls.logger.debug "None of the rule repository drivers claim to have the rule"
+        raise Togls::RepositoryRuleDataInvalid, "None of the rule repository drivers claim to have the rule"
+      end
 
       ['type_id', 'data', 'target_type'].each do |k|
-        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data that is missing the '#{k}'" unless rule_data.has_key? k
+        if !rule_data.has_key? k
+          Togls.logger.debug "One of the rule repository drivers returned rule data that is missing the '#{k}'"
+          raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data that is missing the '#{k}'"
+        end
       end
 
       ['type_id', 'target_type'].each do |k|
-        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data with '#{k}' not being a string" unless rule_data[k].is_a?(String)
+        if !rule_data[k].is_a?(String)
+          Togls.logger.debug "One of the rule repository drivers returned rule data with '#{k}' not being a string"
+          raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data with '#{k}' not being a string"
+        end
       end
     end
 

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -42,7 +42,20 @@ module Togls
 
     def get(rule_id)
       rule_data = fetch_rule_data(rule_id)
+      validate_rule_data(rule_data)
       reconstitute_rule(rule_data)
+    end
+
+    def validate_rule_data(rule_data)
+      raise Togls::RepositoryRuleDataInvalid, "None of the rule repository drivers claim to have the rule" if rule_data.nil?
+
+      required_keys = ['type_id', 'data', 'target_type'].each do |k|
+        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data that is missing the '#{k}'" if !rule_data.has_key? k
+      end
+
+      string_keys = ['type_id', 'target_type'].each do |k|
+        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data with '#{k}' not being a string" if !rule_data[k].is_a?(String)
+      end
     end
 
     def reconstitute_rule(rule_data)

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -49,11 +49,11 @@ module Togls
     def validate_rule_data(rule_data)
       raise Togls::RepositoryRuleDataInvalid, "None of the rule repository drivers claim to have the rule" if rule_data.nil?
 
-      required_keys = ['type_id', 'data', 'target_type'].each do |k|
+      ['type_id', 'data', 'target_type'].each do |k|
         raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data that is missing the '#{k}'" unless rule_data.has_key? k
       end
 
-      string_keys = ['type_id', 'target_type'].each do |k|
+      ['type_id', 'target_type'].each do |k|
         raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data with '#{k}' not being a string" unless rule_data[k].is_a?(String)
       end
     end

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -50,11 +50,11 @@ module Togls
       raise Togls::RepositoryRuleDataInvalid, "None of the rule repository drivers claim to have the rule" if rule_data.nil?
 
       required_keys = ['type_id', 'data', 'target_type'].each do |k|
-        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data that is missing the '#{k}'" if !rule_data.has_key? k
+        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data that is missing the '#{k}'" unless rule_data.has_key? k
       end
 
       string_keys = ['type_id', 'target_type'].each do |k|
-        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data with '#{k}' not being a string" if !rule_data[k].is_a?(String)
+        raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data with '#{k}' not being a string" unless rule_data[k].is_a?(String)
       end
     end
 

--- a/lib/togls/rule_repository_drivers/env_override_driver.rb
+++ b/lib/togls/rule_repository_drivers/env_override_driver.rb
@@ -10,9 +10,9 @@ module Togls
 
       def get(rule_id)
         if rule_id == Togls::Helpers.sha1(Togls::Rules::Boolean, true) 
-          return { 'type_id' => 'boolean', 'data' => true }
+          return { 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s }
         elsif rule_id == Togls::Helpers.sha1(Togls::Rules::Boolean, false)
-          return { 'type_id' => 'boolean', 'data' => false }
+          return { 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s }
         else
           nil
         end

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -39,12 +39,14 @@ module Togls
       begin
         feature = @feature_repository.get(toggle_data['feature_id'])
       rescue Togls::RepositoryFeatureDataInvalid => e
+        Togls.logger.warn("Feature Repository failed to get feature due to invalid feature data")
         return Togls::NullToggle.new
       end
 
       begin
         rule = @rule_repository.get(toggle_data['rule_id'])
       rescue Togls::RepositoryRuleDataInvalid => e
+        Togls.logger.warn("Rule Repository failed to get rule due to invalid rule data")
         return Togls::NullToggle.new
       end
 

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -41,7 +41,13 @@ module Togls
       rescue Togls::RepositoryFeatureDataInvalid => e
         return Togls::NullToggle.new
       end
-      rule = @rule_repository.get(toggle_data['rule_id'])
+
+      begin
+        rule = @rule_repository.get(toggle_data['rule_id'])
+      rescue Togls::RepositoryRuleDataInvalid => e
+        return Togls::NullToggle.new
+      end
+
       toggle = Togls::Toggle.new(feature)
       begin
         toggle.rule = rule

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -36,7 +36,11 @@ module Togls
     end
 
     def reconstitute_toggle(toggle_data)
-      feature = @feature_repository.get(toggle_data['feature_id'])
+      begin
+        feature = @feature_repository.get(toggle_data['feature_id'])
+      rescue Togls::RepositoryFeatureDataInvalid => e
+        return Togls::NullToggle.new
+      end
       rule = @rule_repository.get(toggle_data['rule_id'])
       toggle = Togls::Toggle.new(feature)
       begin

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -39,14 +39,12 @@ module Togls
       begin
         feature = @feature_repository.get(toggle_data['feature_id'])
       rescue Togls::RepositoryFeatureDataInvalid => e
-        Togls.logger.warn("Feature Repository failed to get feature due to invalid feature data")
         return Togls::NullToggle.new
       end
 
       begin
         rule = @rule_repository.get(toggle_data['rule_id'])
       rescue Togls::RepositoryRuleDataInvalid => e
-        Togls.logger.warn("Rule Repository failed to get rule due to invalid rule data")
         return Togls::NullToggle.new
       end
 

--- a/spec/togls/feature_repository_spec.rb
+++ b/spec/togls/feature_repository_spec.rb
@@ -156,12 +156,22 @@ describe Togls::FeatureRepository do
   describe "#get" do
     it "get the feature data" do
       allow(subject).to receive(:reconstitute_feature)
+      allow(subject).to receive(:validate_feature_data)
       expect(subject).to receive(:fetch_feature_data).with("some_id")
+      subject.get("some_id")
+    end
+
+    it 'validates the feature data' do
+      feature_data = { "key" => "some_key", "description" => "some desc",
+        "target_type" => "some_target_type" }
+      allow(subject).to receive(:fetch_feature_data).and_return(feature_data)
+      expect(subject).to receive(:validate_feature_data).with(feature_data)
       subject.get("some_id")
     end
 
     it "reconstitutes a feature" do
       feature_data = double('feature data')
+      allow(subject).to receive(:validate_feature_data)
       allow(subject).to receive(:fetch_feature_data).and_return(feature_data)
       expect(subject).to receive(:reconstitute_feature).with(feature_data)
       subject.get("some_id")
@@ -169,6 +179,7 @@ describe Togls::FeatureRepository do
 
     it "returns the feature" do
       feature = double('feature')
+      allow(subject).to receive(:validate_feature_data)
       allow(subject).to receive(:fetch_feature_data)
       allow(subject).to receive(:reconstitute_feature).and_return(feature)
       expect(subject.get("some_id")).to eq(feature)
@@ -176,15 +187,7 @@ describe Togls::FeatureRepository do
   end
 
   describe "#reconstitute_feature" do
-    it 'validates the feature data' do
-      feature_data = { "key" => "some_key", "description" => "some desc",
-        "target_type" => "some_target_type" }
-      expect(subject).to receive(:validate_feature_data).with(feature_data)
-      subject.reconstitute_feature(feature_data)
-    end
-
     it "constructs a feature from the feature data" do
-      allow(subject).to receive(:validate_feature_data)
       expect(Togls::Feature).to receive(:new).with("some_key", "some desc",
                                                    :some_target_type)
       subject.reconstitute_feature({ "key" => "some_key",
@@ -193,7 +196,6 @@ describe Togls::FeatureRepository do
     end
 
     it "returns the feature" do
-      allow(subject).to receive(:validate_feature_data)
       feature = double('feature')
       allow(Togls::Feature).to receive(:new).and_return(feature)
       expect(subject.reconstitute_feature({ "key" => "some_key", "description" => "some desc",

--- a/spec/togls/feature_repository_spec.rb
+++ b/spec/togls/feature_repository_spec.rb
@@ -215,8 +215,9 @@ describe Togls::FeatureRepository do
     end
 
     context 'when feature data is nil' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         feature_data = nil
+        expect(Togls.logger).to receive(:debug).with("None of the feature repository drivers claim to have the feature")
         expect {
           subject.validate_feature_data(feature_data)
         }.to raise_error(Togls::RepositoryFeatureDataInvalid)
@@ -224,9 +225,10 @@ describe Togls::FeatureRepository do
     end
 
     context 'when feature data is missing key' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         feature_data = { "description" => "some desc",
           "target_type" => "some_target_type" }
+        expect(Togls.logger).to receive(:debug).with("One of the feature repository drivers returned feature data that is missing the 'key'")
         expect {
           subject.validate_feature_data(feature_data)
         }.to raise_error(Togls::RepositoryFeatureDataInvalid)
@@ -234,9 +236,10 @@ describe Togls::FeatureRepository do
     end
 
     context 'when feature data is missing description' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         feature_data = { "key" => "some_key",
           "target_type" => "some_target_type" }
+        expect(Togls.logger).to receive(:debug).with("One of the feature repository drivers returned feature data that is missing the 'description'")
         expect {
           subject.validate_feature_data(feature_data)
         }.to raise_error(Togls::RepositoryFeatureDataInvalid)
@@ -244,8 +247,9 @@ describe Togls::FeatureRepository do
     end
 
     context 'when feature data is missing target_type' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         feature_data = { "key" => "some_key", "description" => "some desc" }
+        expect(Togls.logger).to receive(:debug).with("One of the feature repository drivers returned feature data that is missing the 'target_type'")
         expect {
           subject.validate_feature_data(feature_data)
         }.to raise_error(Togls::RepositoryFeatureDataInvalid)
@@ -253,8 +257,9 @@ describe Togls::FeatureRepository do
     end
 
     context 'when feature data key is not a string' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         feature_data = { "key" => 12342, "description" => "some desc", "target_type" => "some_target_type" }
+        expect(Togls.logger).to receive(:debug).with("One of the feature repository drivers returned feature data with 'key' not being a string")
         expect {
           subject.validate_feature_data(feature_data)
         }.to raise_error(Togls::RepositoryFeatureDataInvalid)
@@ -262,8 +267,9 @@ describe Togls::FeatureRepository do
     end
 
     context 'when feature data description is not a string' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         feature_data = { "key" => "foo", "description" => 234324, "target_type" => "some_target_type" }
+        expect(Togls.logger).to receive(:debug).with("One of the feature repository drivers returned feature data with 'description' not being a string")
         expect {
           subject.validate_feature_data(feature_data)
         }.to raise_error(Togls::RepositoryFeatureDataInvalid)
@@ -271,8 +277,9 @@ describe Togls::FeatureRepository do
     end
 
     context 'when feature data target_type is not a string' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         feature_data = { "key" => "foo", "description" => "aoeuaoe", "target_type" => 2343242 }
+        expect(Togls.logger).to receive(:debug).with("One of the feature repository drivers returned feature data with 'target_type' not being a string")
         expect {
           subject.validate_feature_data(feature_data)
         }.to raise_error(Togls::RepositoryFeatureDataInvalid)

--- a/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
@@ -12,14 +12,14 @@ describe Togls::RuleRepositoryDrivers::EnvOverrideDriver do
     context 'when requesting a boolean rule with true' do
       it 'returns a boolean rule type with true' do
         rule_id = Togls::Helpers.sha1(Togls::Rules::Boolean, true)
-        expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => true })
+        expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end
 
     context 'when requesting a boolean rule with false' do
       it 'returns a boolean rule type with false' do
         rule_id = Togls::Helpers.sha1(Togls::Rules::Boolean, false)
-        expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => false })
+        expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end
 

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -151,12 +151,22 @@ describe Togls::RuleRepository do
   describe "#get" do
     it "get the rule data" do
       expect(subject).to receive(:fetch_rule_data).with("some_id")
+      allow(subject).to receive(:validate_rule_data)
       allow(subject).to receive(:reconstitute_rule)
       subject.get("some_id")
     end
 
+    it 'validates the fetched rule data' do
+      rule_data = double('rule data')
+      allow(subject).to receive(:fetch_rule_data).with('some_id').and_return(rule_data)
+      allow(subject).to receive(:reconstitute_rule)
+      expect(subject).to receive(:validate_rule_data).with(rule_data)
+      subject.get('some_id')
+    end
+
     it "reconstitutes a rule" do
       rule_data = double('rule data')
+      allow(subject).to receive(:validate_rule_data)
       allow(subject).to receive(:fetch_rule_data).and_return(rule_data)
       expect(subject).to receive(:reconstitute_rule).with(rule_data)
       subject.get("some_id")
@@ -164,9 +174,75 @@ describe Togls::RuleRepository do
 
     it "returns the rule" do
       rule = double('rule')
+      allow(subject).to receive(:validate_rule_data)
       allow(subject).to receive(:fetch_rule_data)
       allow(subject).to receive(:reconstitute_rule).and_return(rule)
       expect(subject.get("some_id")).to eq(rule)
+    end
+  end
+
+  describe '#validate_rule_data' do
+    context 'when rule data is complete and proper' do
+      it 'does not raise an exception' do
+        rule_data = { 'type_id' => 'sometype', 'data' => 'somedata', 'target_type' => 'sometype' }
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.not_to raise_error
+      end
+    end
+
+    context 'when rule data is nil' do
+      it 'raises an exception' do
+        rule_data = nil
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
+    end
+
+    context 'when rule data is missing type_id' do
+      it 'raises an exception' do
+        rule_data = { 'data' => 'somedata', 'target_type' => 'sometype' }
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
+    end
+
+    context 'when rule data is missing data' do
+      it 'raises an exception' do
+        rule_data = { 'type_id' => 'sometype', 'target_type' => 'sometype' }
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
+    end
+
+    context 'when rule data is missing target_type' do
+      it 'raises an exception' do
+        rule_data = { 'type_id' => 'sometype', 'data' => 'somedata' }
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
+    end
+
+    context 'when rule data type_id is not a string' do
+      it 'raises an exception' do
+        rule_data = { 'type_id' => 232323, 'data' => 'somedata', 'target_type' => 'sometype' }
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
+    end
+
+    context 'when rule data target_type is not a string' do
+      it 'raises an exception' do
+        rule_data = { 'type_id' => 'aoeua', 'data' => 'aoeu', 'target_type' => 23423 }
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
     end
   end
 

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -192,8 +192,9 @@ describe Togls::RuleRepository do
     end
 
     context 'when rule data is nil' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         rule_data = nil
+        expect(Togls.logger).to receive(:debug).with("None of the rule repository drivers claim to have the rule")
         expect {
           subject.validate_rule_data(rule_data)
         }.to raise_error(Togls::RepositoryRuleDataInvalid)
@@ -201,8 +202,9 @@ describe Togls::RuleRepository do
     end
 
     context 'when rule data is missing type_id' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         rule_data = { 'data' => 'somedata', 'target_type' => 'sometype' }
+        expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'type_id'")
         expect {
           subject.validate_rule_data(rule_data)
         }.to raise_error(Togls::RepositoryRuleDataInvalid)
@@ -210,8 +212,9 @@ describe Togls::RuleRepository do
     end
 
     context 'when rule data is missing data' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         rule_data = { 'type_id' => 'sometype', 'target_type' => 'sometype' }
+        expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'data'")
         expect {
           subject.validate_rule_data(rule_data)
         }.to raise_error(Togls::RepositoryRuleDataInvalid)
@@ -219,8 +222,9 @@ describe Togls::RuleRepository do
     end
 
     context 'when rule data is missing target_type' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         rule_data = { 'type_id' => 'sometype', 'data' => 'somedata' }
+        expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'target_type'")
         expect {
           subject.validate_rule_data(rule_data)
         }.to raise_error(Togls::RepositoryRuleDataInvalid)
@@ -228,8 +232,9 @@ describe Togls::RuleRepository do
     end
 
     context 'when rule data type_id is not a string' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         rule_data = { 'type_id' => 232323, 'data' => 'somedata', 'target_type' => 'sometype' }
+        expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data with 'type_id' not being a string")
         expect {
           subject.validate_rule_data(rule_data)
         }.to raise_error(Togls::RepositoryRuleDataInvalid)
@@ -237,8 +242,9 @@ describe Togls::RuleRepository do
     end
 
     context 'when rule data target_type is not a string' do
-      it 'raises an exception' do
+      it 'logs and raises an exception' do
         rule_data = { 'type_id' => 'aoeua', 'data' => 'aoeu', 'target_type' => 23423 }
+        expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data with 'target_type' not being a string")
         expect {
           subject.validate_rule_data(rule_data)
         }.to raise_error(Togls::RepositoryRuleDataInvalid)

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -173,6 +173,14 @@ describe Togls::ToggleRepository do
       subject.reconstitute_toggle(toggle_data)
     end
 
+    context 'when fails to fetch a feature' do
+      it 'short circuits and returns a null toggle' do
+        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
+        allow(feature_repository).to receive(:get).and_raise(Togls::RepositoryFeatureDataInvalid)
+        expect(subject.reconstitute_toggle(toggle_data)).to be_a(Togls::NullToggle)
+      end
+    end
+
     it "fetches the referenced rule from the rule repository" do
       toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
       toggle = double('toggle')

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -191,6 +191,15 @@ describe Togls::ToggleRepository do
       subject.reconstitute_toggle(toggle_data)
     end
 
+    context 'when fails to fetch a rule' do
+      it 'short circuits and returns a null toggle' do
+        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
+        allow(feature_repository).to receive(:get)
+        allow(rule_repository).to receive(:get).and_raise(Togls::RepositoryRuleDataInvalid)
+        expect(subject.reconstitute_toggle(toggle_data)).to be_a(Togls::NullToggle)
+      end
+    end
+
     it "constructs a toggle with the fetcthed feature" do
       toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
       feature = double('feature')

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -174,8 +174,16 @@ describe Togls::ToggleRepository do
     end
 
     context 'when fails to fetch a feature' do
+      it 'logs the failure' do
+        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
+        allow(feature_repository).to receive(:get).and_raise(Togls::RepositoryFeatureDataInvalid)
+        expect(Togls.logger).to receive(:warn).with("Feature Repository failed to get feature due to invalid feature data")
+        subject.reconstitute_toggle(toggle_data)
+      end
+
       it 'short circuits and returns a null toggle' do
         toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
+        allow(Togls.logger).to receive(:warn)
         allow(feature_repository).to receive(:get).and_raise(Togls::RepositoryFeatureDataInvalid)
         expect(subject.reconstitute_toggle(toggle_data)).to be_a(Togls::NullToggle)
       end
@@ -192,9 +200,18 @@ describe Togls::ToggleRepository do
     end
 
     context 'when fails to fetch a rule' do
+      it 'logs the failure' do
+        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
+        allow(feature_repository).to receive(:get)
+        allow(rule_repository).to receive(:get).and_raise(Togls::RepositoryRuleDataInvalid)
+        expect(Togls.logger).to receive(:warn).with("Rule Repository failed to get rule due to invalid rule data")
+        subject.reconstitute_toggle(toggle_data)
+      end
+
       it 'short circuits and returns a null toggle' do
         toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
         allow(feature_repository).to receive(:get)
+        allow(Togls.logger).to receive(:warn)
         allow(rule_repository).to receive(:get).and_raise(Togls::RepositoryRuleDataInvalid)
         expect(subject.reconstitute_toggle(toggle_data)).to be_a(Togls::NullToggle)
       end

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -174,13 +174,6 @@ describe Togls::ToggleRepository do
     end
 
     context 'when fails to fetch a feature' do
-      it 'logs the failure' do
-        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
-        allow(feature_repository).to receive(:get).and_raise(Togls::RepositoryFeatureDataInvalid)
-        expect(Togls.logger).to receive(:warn).with("Feature Repository failed to get feature due to invalid feature data")
-        subject.reconstitute_toggle(toggle_data)
-      end
-
       it 'short circuits and returns a null toggle' do
         toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
         allow(Togls.logger).to receive(:warn)
@@ -200,14 +193,6 @@ describe Togls::ToggleRepository do
     end
 
     context 'when fails to fetch a rule' do
-      it 'logs the failure' do
-        toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
-        allow(feature_repository).to receive(:get)
-        allow(rule_repository).to receive(:get).and_raise(Togls::RepositoryRuleDataInvalid)
-        expect(Togls.logger).to receive(:warn).with("Rule Repository failed to get rule due to invalid rule data")
-        subject.reconstitute_toggle(toggle_data)
-      end
-
       it 'short circuits and returns a null toggle' do
         toggle_data = { "feature_id" => "badges", "rule_id" => "ba234aoeubaooea23" }
         allow(feature_repository).to receive(:get)


### PR DESCRIPTION
This adds the necessary handling of exceptions to the toggle reconstitution process.

It accomplishes this by first adding payload validation checking to both the rule and feature repositories so that they can identify and report invalid payloads via exception up to the toggle reconstitution process in the toggle repository.

This also includes fixes to add the `target_type` to the rule environment override driver which we missed and the validation checker aided in identifying.

This is my solution for #80 