### PR TITLE
Fix env override drivers to use new rule

### DIFF
--- a/lib/togls/rule_repository_drivers/env_override_driver.rb
+++ b/lib/togls/rule_repository_drivers/env_override_driver.rb
@@ -9,9 +9,11 @@ module Togls
       end
 
       def get(rule_id)
-        if rule_id == Togls::Helpers.sha1(Togls::Rules::Boolean, true) 
+        boolean_false = Togls::Rules::Boolean.new(:boolean, false)
+        boolean_true = Togls::Rules::Boolean.new(:boolean, true)
+        if rule_id == boolean_true.id
           return { 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s }
-        elsif rule_id == Togls::Helpers.sha1(Togls::Rules::Boolean, false)
+        elsif rule_id == boolean_false.id
           return { 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s }
         else
           nil

--- a/lib/togls/toggle_repository_drivers/env_override_driver.rb
+++ b/lib/togls/toggle_repository_drivers/env_override_driver.rb
@@ -22,11 +22,11 @@ module Togls
       def get(toggle_id)
         return nil if ENV[toggle_env_key(toggle_id)].nil?
         if ENV[toggle_env_key(toggle_id)] == 'true'
-          return { 'feature_id' => toggle_id, 'rule_id' => Togls::Helpers.sha1(
-            Togls::Rules::Boolean, true) }
+          return { 'feature_id' => toggle_id, 'rule_id' =>
+                   Togls::Rules::Boolean.new(:boolean, true).id }
         elsif ENV[toggle_env_key(toggle_id)] == 'false'
-          return { 'feature_id' => toggle_id, 'rule_id' => Togls::Helpers.sha1(
-            Togls::Rules::Boolean, false) }
+          return { 'feature_id' => toggle_id, 'rule_id' =>
+                   Togls::Rules::Boolean.new(:boolean, false).id }
         else
           return nil
         end

--- a/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
@@ -11,21 +11,21 @@ RSpec.describe Togls::RuleRepositoryDrivers::EnvOverrideDriver do
   describe 'retrieving' do
     context 'when requesting a boolean rule with true' do
       it 'returns a boolean rule type with true' do
-        rule_id = Togls::Helpers.sha1(Togls::Rules::Boolean, true)
+        rule_id = Togls::Rules::Boolean.new(:boolean, true).id
         expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end
 
     context 'when requesting a boolean rule with false' do
       it 'returns a boolean rule type with false' do
-        rule_id = Togls::Helpers.sha1(Togls::Rules::Boolean, false)
+        rule_id = Togls::Rules::Boolean.new(:boolean, false).id
         expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end
 
     context 'when requesting any other type of rule' do
       it 'returns nil' do
-        rule_id = Togls::Helpers.sha1(Togls::Rule, nil)
+        rule_id = 'aeuaoeuao'
         expect(subject.get(rule_id)).to be_nil
       end
     end

--- a/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
 
         it "returns Togls::Rules::Boolean true toggle data" do
           expect(subject.get("some_toggle_id")).to eq({ "feature_id" => "some_toggle_id",
-                     "rule_id" => Togls::Helpers.sha1(Togls::Rules::Boolean, true) })
+                     "rule_id" => Togls::Rules::Boolean.new(:boolean, true).id })
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
 
         it "returns Togls::Rules::Boolean false toggle data" do
           expect(subject.get("some_toggle_id")).to eq({ "feature_id" => "some_toggle_id",
-                     "rule_id" => Togls::Helpers.sha1(Togls::Rules::Boolean, false) })
+                     "rule_id" => Togls::Rules::Boolean.new(:boolean, false).id })
         end
       end
 


### PR DESCRIPTION
Why you made the change:

I did this because it was broken without this change since rules now require the
type_id, etc.