### PR TITLE
Extract rule repository drivers into a method

### DIFF
--- a/lib/togls/rule_manager.rb
+++ b/lib/togls/rule_manager.rb
@@ -37,13 +37,15 @@ module Togls
         @rule_type_registry
       end
 
+      def rule_repository_drivers
+        rule_repository_drivers = [
+          Togls::RuleRepositoryDrivers::InMemoryDriver.new,
+          Togls::RuleRepositoryDrivers::EnvOverrideDriver.new
+        ]
+      end
+
       def rule_repository
         if @rule_repository.nil?
-          rule_repository_drivers = [
-            Togls::RuleRepositoryDrivers::InMemoryDriver.new,
-            Togls::RuleRepositoryDrivers::EnvOverrideDriver.new
-          ]
-
           @rule_repository = Togls::RuleRepository.new(rule_repository_drivers)
         end
         @rule_repository


### PR DESCRIPTION
Why you made the change:

I did this so that the code would be cleaned up a bit and so that it would make
it easier to integrate additional drivers.