### PR TITLE
Make fallback resort to next toggle driver

### DIFF
--- a/lib/togls/null_toggle.rb
+++ b/lib/togls/null_toggle.rb
@@ -18,6 +18,5 @@ module Togls
     end
   end
 
-  class ToggleMissingToggle < NullToggle; end
   class RuleFeatureMismatchToggle < NullToggle; end
 end

--- a/lib/togls/toggle_registry.rb
+++ b/lib/togls/toggle_registry.rb
@@ -31,15 +31,7 @@ module Togls
     end
 
     def get(key)
-      toggle = @toggle_repository.get(key.to_s)
-      if toggle.is_a?(Togls::ToggleMissingToggle)
-        Togls.logger.warn("Feature identified by '#{key}' has not been defined")
-      end
-      toggle
-    end
-
-    def all
-      @toggle_repository.all
+      @toggle_repository.get(key.to_s)
     end
   end
 end

--- a/lib/togls/toggle_repository_drivers/env_override_driver.rb
+++ b/lib/togls/toggle_repository_drivers/env_override_driver.rb
@@ -32,10 +32,6 @@ module Togls
         end
       end
 
-      def all
-        {}
-      end
-
       private
 
       def toggle_env_key(toggle_id)

--- a/lib/togls/toggle_repository_drivers/in_memory_driver.rb
+++ b/lib/togls/toggle_repository_drivers/in_memory_driver.rb
@@ -27,14 +27,6 @@ module Togls
           end
         end
       end
-
-      def all
-        result = {}
-        @toggles_lock.synchronize do
-          @toggles.each_pair { |k, v| result[k] = Marshal.load(v) }
-        end
-        result
-      end
     end
   end
 end

--- a/spec/togls/toggle_registry_spec.rb
+++ b/spec/togls/toggle_registry_spec.rb
@@ -122,38 +122,11 @@ RSpec.describe Togls::ToggleRegistry do
       subject.get("some key")
     end
 
-    context "when the toggle is found" do
-      it "returns the obtained feature toggle" do
-        toggle = double('toggle')
-        toggle_repository = subject.instance_variable_get(:@toggle_repository)
-        allow(toggle_repository).to receive(:get).and_return(toggle)
-        expect(subject.get("some key")).to eq(toggle)
-      end
-    end
-
-    context "when the toggle is NOT found" do
-      before do
-        toggle_missing_toggle = Togls::ToggleMissingToggle.new
-        toggle_repository = subject.instance_variable_get(:@toggle_repository)
-        allow(toggle_repository).to receive(:get).and_return(toggle_missing_toggle)
-      end
-
-      it "logs a warning" do
-        expect(Togls.logger).to receive(:warn).with("Feature identified by 'some_id' has not been defined")
-        subject.get("some_id")
-      end
-
-      it "returns a null toggle" do
-        expect(subject.get("some not real key")).to be_a(Togls::ToggleMissingToggle)
-      end
-    end
-  end
-
-  describe "#all" do
-    it "fetches all toggles" do
+    it "returns the obtained feature toggle" do
+      toggle = double('toggle')
       toggle_repository = subject.instance_variable_get(:@toggle_repository)
-      expect(toggle_repository).to receive(:all)
-      subject.all
+      allow(toggle_repository).to receive(:get).and_return(toggle)
+      expect(subject.get("some key")).to eq(toggle)
     end
   end
 end

--- a/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
@@ -60,10 +60,4 @@ RSpec.describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
       end
     end
   end
-
-  describe "#all" do
-    it "passively returns an empty hash" do
-      expect(subject.all).to eq({})
-    end
-  end
 end

--- a/spec/togls/toggle_repository_drivers/in_memory_driver_spec.rb
+++ b/spec/togls/toggle_repository_drivers/in_memory_driver_spec.rb
@@ -27,14 +27,4 @@ RSpec.describe Togls::ToggleRepositoryDrivers::InMemoryDriver do
       end
     end
   end
-
-  describe "#all" do
-    it "returns the collection of toggles" do
-      feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
-      toggle = Togls::Toggle.new(feature)
-      toggle_data = { 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id }
-      subject.store(toggle.id, toggle_data)
-      expect(subject.all).to eq({"some_feature_key"=>{"feature_id"=>toggle.feature.id, "rule_id"=>toggle.rule.id}})
-    end
-  end
 end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe "Togl" do
         toggle.instance_variable_set(:@rule, a)
         toggle_repo.store(toggle)
 
-        expect(Togls.feature(:hoopty).instance_variable_get(:@toggle)).to be_a(Togls::RuleFeatureMismatchToggle)
+        expect(Togls.feature(:hoopty).instance_variable_get(:@toggle)).to be_a(Togls::NullToggle)
         expect(Togls.feature(:hoopty).on?).to eq(false)
       end
     end


### PR DESCRIPTION
Why you made the change:

I did this because previously when toggle reconstitution would fail due to a
miss-match, or a missing value, etc. It would simply return a NullToggle. This
short-circuited the process and resulted in the toggle evaluating to false. The
problem was that it was not falling back to the other toggle drivers and
eventually falling back to the defaults held by the in-memory drivers.

I resolved this by modifying the toggle repository `get` method to check the
success/failure of toggle reconstitution and fall back to the previous toggle
drivers if reconstitution failed. This will make it so that if for any of the
above possible reasons for failure, it will follow the natural driver fallback
path rather than short-circuiting with a NullToggle.