### PR TITLE
Make rules identified by abstract string rule id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Changed`: Rules to be identified by an abstract given string id
 * `Changed`: Rule and Rule Type management to be global under Togls
 * `Changed`: The testing interface to allow for contract enforcement in tests
   and allow altering existing feature rules within tests.

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -4,7 +4,7 @@ module Togls
   # The Rule is an abstract base class that is intended to act as an interface
   # for other rules to be implemented against.
   class Rule
-    attr_reader :data, :type_id
+    attr_reader :data, :type_id, :id
 
     def self.title
       raise Togls::NotImplemented, "Rule type title not implemented"
@@ -28,10 +28,6 @@ module Togls
 
     def run(key, target = nil)
       raise Togls::NotImplemented, "Rule's #run method must be implemented"
-    end
-
-    def id
-      @id.to_s
     end
 
     def target_type

--- a/lib/togls/rule.rb
+++ b/lib/togls/rule.rb
@@ -18,7 +18,8 @@ module Togls
       Togls::TargetTypes::NOT_SET
     end
 
-    def initialize(type_id, data = nil, target_type: Togls::TargetTypes::NOT_SET)
+    def initialize(id, type_id, data = nil, target_type: Togls::TargetTypes::NOT_SET)
+      @id = id
       @type_id = type_id
       @data = data
       @target_type = target_type
@@ -30,7 +31,7 @@ module Togls
     end
 
     def id
-      Togls::Helpers.sha1(@type_id, @data, target_type)
+      @id.to_s
     end
 
     def target_type

--- a/lib/togls/rule_manager.rb
+++ b/lib/togls/rule_manager.rb
@@ -14,8 +14,8 @@ module Togls
         rule_type_registry.get(type_id)
       end
 
-      def rule(type_id, data = nil, target_type: Togls::TargetTypes::NOT_SET)
-        rule_type(type_id).new(type_id, data, target_type: target_type)
+      def rule(id, type_id, data = nil, target_type: Togls::TargetTypes::NOT_SET)
+        rule_type(type_id).new(id, type_id, data, target_type: target_type)
       end
 
       private

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -24,8 +24,9 @@ module Togls
 
     def extract_storage_payload(rule)
       {
+        'id' => rule.id,
         'type_id' => ::Togls.send(:rule_type_registry).get_type_id(rule.class.to_s),
-        'data' => rule.data, 
+        'data' => rule.data,
         'target_type' => rule.target_type.to_s
       }
     end
@@ -51,14 +52,14 @@ module Togls
         raise Togls::RepositoryRuleDataInvalid, "None of the rule repository drivers claim to have the rule"
       end
 
-      ['type_id', 'data', 'target_type'].each do |k|
+      ['id', 'type_id', 'data', 'target_type'].each do |k|
         if !rule_data.has_key? k
           Togls.logger.debug "One of the rule repository drivers returned rule data that is missing the '#{k}'"
           raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data that is missing the '#{k}'"
         end
       end
 
-      ['type_id', 'target_type'].each do |k|
+      ['id', 'type_id', 'target_type'].each do |k|
         if !rule_data[k].is_a?(String)
           Togls.logger.debug "One of the rule repository drivers returned rule data with '#{k}' not being a string"
           raise Togls::RepositoryRuleDataInvalid, "One of the rule repository drivers returned rule data with '#{k}' not being a string"
@@ -69,10 +70,11 @@ module Togls
     def reconstitute_rule(rule_data)
       if rule_data.has_key?('target_type')
         ::Togls.rule_type(rule_data['type_id'])\
-          .new(rule_data['type_id'].to_sym, rule_data['data'],
+          .new(rule_data['id'].to_sym, rule_data['type_id'].to_sym, rule_data['data'],
                target_type: rule_data['target_type'].to_sym)
       else
-        ::Togls.rule_type(rule_data['type_id']).new(rule_data['type_id'].to_sym,
+        ::Togls.rule_type(rule_data['type_id']).new(rule_data['id'].to_sym,
+                                                    rule_data['type_id'].to_sym,
                                                     rule_data['data'])
       end
     end

--- a/lib/togls/rule_repository.rb
+++ b/lib/togls/rule_repository.rb
@@ -18,13 +18,13 @@ module Togls
     def store(rule)
       rule_data = extract_storage_payload(rule)
       @drivers.each do |driver|
-        driver.store(rule.id, rule_data)
+        driver.store(rule.id.to_s, rule_data)
       end
     end
 
     def extract_storage_payload(rule)
       {
-        'id' => rule.id,
+        'id' => rule.id.to_s,
         'type_id' => ::Togls.send(:rule_type_registry).get_type_id(rule.class.to_s),
         'data' => rule.data,
         'target_type' => rule.target_type.to_s

--- a/lib/togls/rule_repository_drivers/env_override_driver.rb
+++ b/lib/togls/rule_repository_drivers/env_override_driver.rb
@@ -11,9 +11,9 @@ module Togls
       def get(rule_id)
         boolean_false = Togls::Rules::Boolean.new(:off, :boolean, false)
         boolean_true = Togls::Rules::Boolean.new(:on, :boolean, true)
-        if rule_id == boolean_true.id
+        if rule_id == boolean_true.id.to_s
           return { 'id' => 'on', 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s }
-        elsif rule_id == boolean_false.id
+        elsif rule_id == boolean_false.id.to_s
           return { 'id' => 'off', 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s }
         else
           nil

--- a/lib/togls/rule_repository_drivers/env_override_driver.rb
+++ b/lib/togls/rule_repository_drivers/env_override_driver.rb
@@ -9,12 +9,12 @@ module Togls
       end
 
       def get(rule_id)
-        boolean_false = Togls::Rules::Boolean.new(:boolean, false)
-        boolean_true = Togls::Rules::Boolean.new(:boolean, true)
+        boolean_false = Togls::Rules::Boolean.new(:off, :boolean, false)
+        boolean_true = Togls::Rules::Boolean.new(:on, :boolean, true)
         if rule_id == boolean_true.id
-          return { 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s }
+          return { 'id' => 'on', 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s }
         elsif rule_id == boolean_false.id
-          return { 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s }
+          return { 'id' => 'off', 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s }
         else
           nil
         end

--- a/lib/togls/rules/boolean.rb
+++ b/lib/togls/rules/boolean.rb
@@ -6,7 +6,7 @@ module Togls
     # it's initialization data and when evaluated determines the toggle state
     # based on the initialization value. Example:
     #
-    # always_on = Togls::Rules::Boolean.new(:boolean, true)
+    # always_on = Togls::Rules::Boolean.new(:on, :boolean, true)
     # Togls.features do
     #   feature(:foo).on(always_on)
     # end
@@ -25,9 +25,9 @@ The Boolean rule type is the base line rule for Togls. It allows you to
 flag a feature on/off by specifing a boolean value as the initialization
 data. For example:
 
-Togls::Rules::Boolean.new(:boolean, true) # rule that always evaluates to on
+Togls::Rules::Boolean.new(:on, :boolean, true) # rule that always evaluates to on
 
-Togls::Rules::Boolean.new(:boolean, false) # rule that always evaluates to off
+Togls::Rules::Boolean.new(:off, :boolean, false) # rule that always evaluates to off
         }
       end
 

--- a/lib/togls/toggle.rb
+++ b/lib/togls/toggle.rb
@@ -9,7 +9,7 @@ module Togls
 
     def initialize(feature)
       @feature = feature
-      @rule = Togls::Rules::Boolean.new(:boolean, false)
+      @rule = Togls::Rules::Boolean.new(:off, :boolean, false)
     end
 
     def id

--- a/lib/togls/toggle_repository.rb
+++ b/lib/togls/toggle_repository.rb
@@ -25,7 +25,7 @@ module Togls
     end
 
     def extract_storage_payload(toggle)
-      { 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id }
+      { 'feature_id' => toggle.feature.id, 'rule_id' => toggle.rule.id.to_s }
     end
 
     def get(id)

--- a/lib/togls/toggle_repository_drivers/env_override_driver.rb
+++ b/lib/togls/toggle_repository_drivers/env_override_driver.rb
@@ -23,10 +23,10 @@ module Togls
         return nil if ENV[toggle_env_key(toggle_id)].nil?
         if ENV[toggle_env_key(toggle_id)] == 'true'
           return { 'feature_id' => toggle_id, 'rule_id' =>
-                   Togls::Rules::Boolean.new(:on, :boolean, true).id }
+                   Togls::Rules::Boolean.new(:on, :boolean, true).id.to_s }
         elsif ENV[toggle_env_key(toggle_id)] == 'false'
           return { 'feature_id' => toggle_id, 'rule_id' =>
-                   Togls::Rules::Boolean.new(:off, :boolean, false).id }
+                   Togls::Rules::Boolean.new(:off, :boolean, false).id.to_s }
         else
           return nil
         end

--- a/lib/togls/toggle_repository_drivers/env_override_driver.rb
+++ b/lib/togls/toggle_repository_drivers/env_override_driver.rb
@@ -23,10 +23,10 @@ module Togls
         return nil if ENV[toggle_env_key(toggle_id)].nil?
         if ENV[toggle_env_key(toggle_id)] == 'true'
           return { 'feature_id' => toggle_id, 'rule_id' =>
-                   Togls::Rules::Boolean.new(:boolean, true).id }
+                   Togls::Rules::Boolean.new(:on, :boolean, true).id }
         elsif ENV[toggle_env_key(toggle_id)] == 'false'
           return { 'feature_id' => toggle_id, 'rule_id' =>
-                   Togls::Rules::Boolean.new(:boolean, false).id }
+                   Togls::Rules::Boolean.new(:off, :boolean, false).id }
         else
           return nil
         end

--- a/lib/togls/toggler.rb
+++ b/lib/togls/toggler.rb
@@ -14,14 +14,14 @@ module Togls
     end
 
     def on(rule = nil)
-      rule = Togls::Rules::Boolean.new(:boolean, true) if rule.nil?
+      rule = Togls::Rules::Boolean.new(:on, :boolean, true) if rule.nil?
       @toggle.rule = rule
       @toggle_repository.store(@toggle)
       @toggle
     end
 
     def off
-      rule = Togls::Rules::Boolean.new(:boolean, false)
+      rule = Togls::Rules::Boolean.new(:off, :boolean, false)
       @toggle.rule = rule
       @toggle_repository.store(@toggle)
       @toggle

--- a/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Togls::RuleRepositoryDrivers::EnvOverrideDriver do
   describe 'retrieving' do
     context 'when requesting a boolean rule with true' do
       it 'returns a boolean rule type with true' do
-        rule_id = Togls::Rules::Boolean.new(:boolean, true).id
-        expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s })
+        rule_id = Togls::Rules::Boolean.new(:on, :boolean, true).id
+        expect(subject.get(rule_id)).to eq({ 'id' => 'on', 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end
 
     context 'when requesting a boolean rule with false' do
       it 'returns a boolean rule type with false' do
-        rule_id = Togls::Rules::Boolean.new(:boolean, false).id
-        expect(subject.get(rule_id)).to eq({ 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s })
+        rule_id = Togls::Rules::Boolean.new(:off, :boolean, false).id
+        expect(subject.get(rule_id)).to eq({ 'id' => 'off', 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end
 

--- a/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/rule_repository_drivers/env_override_driver_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Togls::RuleRepositoryDrivers::EnvOverrideDriver do
   describe 'retrieving' do
     context 'when requesting a boolean rule with true' do
       it 'returns a boolean rule type with true' do
-        rule_id = Togls::Rules::Boolean.new(:on, :boolean, true).id
+        rule_id = Togls::Rules::Boolean.new(:on, :boolean, true).id.to_s
         expect(subject.get(rule_id)).to eq({ 'id' => 'on', 'type_id' => 'boolean', 'data' => true, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end
 
     context 'when requesting a boolean rule with false' do
       it 'returns a boolean rule type with false' do
-        rule_id = Togls::Rules::Boolean.new(:off, :boolean, false).id
+        rule_id = Togls::Rules::Boolean.new(:off, :boolean, false).id.to_s
         expect(subject.get(rule_id)).to eq({ 'id' => 'off', 'type_id' => 'boolean', 'data' => false, 'target_type' => Togls::TargetTypes::NONE.to_s })
       end
     end

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Togls::RuleRepository do
       rule_data = double('rule data')
       allow(subject).to receive(:extract_storage_payload).and_return(rule_data)
       allow(subject.instance_variable_get(:@drivers)).to receive(:each).and_yield(driver)
-      expect(driver).to receive(:store).with(rule.id, rule_data)
+      expect(driver).to receive(:store).with(rule.id.to_s, rule_data)
       subject.store(rule)
     end
   end

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Togls::RuleRepository do
       end
     end
 
-    context 'when rule data is id' do
+    context 'when rule data is missing id' do
       it 'logs and raises an exception' do
         rule_data = { 'type_id' => 'foo', 'data' => 'somedata', 'target_type' => 'sometype' }
         expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'id'")

--- a/spec/togls/rule_repository_spec.rb
+++ b/spec/togls/rule_repository_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Togls::RuleRepository do
 
   describe "#store" do
     it "gets the storage payload" do
-      rule = Togls::Rule.new(:sometypeid, target_type: :foo)
+      rule = Togls::Rule.new(:some_rule, :sometypeid, target_type: :foo)
       allow(driver).to receive(:store)
       expect(subject).to receive(:extract_storage_payload).with(rule)
       subject.store(rule)
@@ -48,7 +48,7 @@ RSpec.describe Togls::RuleRepository do
     end
 
     it "store the rule data in each driver" do
-      rule = Togls::Rule.new(:sometypeid, target_type: :foo)
+      rule = Togls::Rule.new(:some_rule, :sometypeid, target_type: :foo)
       rule_data = double('rule data')
       allow(subject).to receive(:extract_storage_payload).and_return(rule_data)
       allow(subject.instance_variable_get(:@drivers)).to receive(:each).and_yield(driver)
@@ -59,16 +59,16 @@ RSpec.describe Togls::RuleRepository do
 
   describe "#extract_storage_payload" do
     it 'gets the rule_type_id from rule type repository' do
-      rule = Togls::Rule.new(:sometypeid, target_type: :foo)
+      rule = Togls::Rule.new(:some_rule, :sometypeid, target_type: :foo)
       expect(::Togls.send(:rule_type_registry)).to receive(:get_type_id).with('Togls::Rule')
       subject.extract_storage_payload(rule)
     end
 
     it 'returns the rule\'s extracted storage payload with the target_type' do
-      rule = Togls::Rule.new(:sometypeid, true, target_type: :foo)
+      rule = Togls::Rule.new(:some_rule, :sometypeid, true, target_type: :foo)
       allow(::Togls.send(:rule_type_registry)).to receive(:get_type_id).with('Togls::Rule').and_return('hoopty')
       expect(subject.extract_storage_payload(rule))
-        .to eq({ 'type_id' => 'hoopty', 'data' => true, 'target_type' => 'foo' })
+        .to eq({ 'id' => 'some_rule', 'type_id' => 'hoopty', 'data' => true, 'target_type' => 'foo' })
     end
   end
 
@@ -176,7 +176,7 @@ RSpec.describe Togls::RuleRepository do
   describe '#validate_rule_data' do
     context 'when rule data is complete and proper' do
       it 'does not raise an exception' do
-        rule_data = { 'type_id' => 'sometype', 'data' => 'somedata', 'target_type' => 'sometype' }
+        rule_data = { 'id' => 'some_rule', 'type_id' => 'sometype', 'data' => 'somedata', 'target_type' => 'sometype' }
         expect {
           subject.validate_rule_data(rule_data)
         }.not_to raise_error
@@ -193,9 +193,19 @@ RSpec.describe Togls::RuleRepository do
       end
     end
 
+    context 'when rule data is id' do
+      it 'logs and raises an exception' do
+        rule_data = { 'type_id' => 'foo', 'data' => 'somedata', 'target_type' => 'sometype' }
+        expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'id'")
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
+    end
+
     context 'when rule data is missing type_id' do
       it 'logs and raises an exception' do
-        rule_data = { 'data' => 'somedata', 'target_type' => 'sometype' }
+        rule_data = { 'id' => 'someid', 'data' => 'somedata', 'target_type' => 'sometype' }
         expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'type_id'")
         expect {
           subject.validate_rule_data(rule_data)
@@ -205,7 +215,7 @@ RSpec.describe Togls::RuleRepository do
 
     context 'when rule data is missing data' do
       it 'logs and raises an exception' do
-        rule_data = { 'type_id' => 'sometype', 'target_type' => 'sometype' }
+        rule_data = { 'id' => 'some_rule', 'type_id' => 'sometype', 'target_type' => 'sometype' }
         expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'data'")
         expect {
           subject.validate_rule_data(rule_data)
@@ -215,8 +225,18 @@ RSpec.describe Togls::RuleRepository do
 
     context 'when rule data is missing target_type' do
       it 'logs and raises an exception' do
-        rule_data = { 'type_id' => 'sometype', 'data' => 'somedata' }
+        rule_data = { 'id' => 'some_rule', 'type_id' => 'sometype', 'data' => 'somedata' }
         expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data that is missing the 'target_type'")
+        expect {
+          subject.validate_rule_data(rule_data)
+        }.to raise_error(Togls::RepositoryRuleDataInvalid)
+      end
+    end
+
+    context 'when rule data id is not a string' do
+      it 'logs and raises an exception' do
+        rule_data = { 'id' => 23423, 'type_id' => 'aoeuaoe', 'data' => 'somedata', 'target_type' => 'sometype' }
+        expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data with 'id' not being a string")
         expect {
           subject.validate_rule_data(rule_data)
         }.to raise_error(Togls::RepositoryRuleDataInvalid)
@@ -225,7 +245,7 @@ RSpec.describe Togls::RuleRepository do
 
     context 'when rule data type_id is not a string' do
       it 'logs and raises an exception' do
-        rule_data = { 'type_id' => 232323, 'data' => 'somedata', 'target_type' => 'sometype' }
+        rule_data = { 'id' => 'some_rule', 'type_id' => 232323, 'data' => 'somedata', 'target_type' => 'sometype' }
         expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data with 'type_id' not being a string")
         expect {
           subject.validate_rule_data(rule_data)
@@ -235,7 +255,7 @@ RSpec.describe Togls::RuleRepository do
 
     context 'when rule data target_type is not a string' do
       it 'logs and raises an exception' do
-        rule_data = { 'type_id' => 'aoeua', 'data' => 'aoeu', 'target_type' => 23423 }
+        rule_data = { 'id' => 'some_rule', 'type_id' => 'aoeua', 'data' => 'aoeu', 'target_type' => 23423 }
         expect(Togls.logger).to receive(:debug).with("One of the rule repository drivers returned rule data with 'target_type' not being a string")
         expect {
           subject.validate_rule_data(rule_data)
@@ -248,24 +268,24 @@ RSpec.describe Togls::RuleRepository do
     context 'when rule data has target_type' do
       it 'constructs a rule with the target type' do
         allow(::Togls.send(:rule_type_registry)).to receive(:get).with('boolean').and_return(Togls::Rules::Boolean)
-        expect(Togls::Rules::Boolean).to receive(:new).with(:boolean, true, target_type: :foo)
-        subject.reconstitute_rule({ 'type_id' => 'boolean', 'data' => true, 'target_type' => 'foo' })
+        expect(Togls::Rules::Boolean).to receive(:new).with(:on, :boolean, true, target_type: :foo)
+        subject.reconstitute_rule({ 'id' => 'on', 'type_id' => 'boolean', 'data' => true, 'target_type' => 'foo' })
       end
     end
 
     context 'when rule data does NOT have a target_type' do
       it 'constructs a rule without a target_type' do
         allow(::Togls.send(:rule_type_registry)).to receive(:get).with('boolean').and_return(Togls::Rules::Boolean)
-        expect(Togls::Rules::Boolean).to receive(:new).with(:boolean, true)
-        subject.reconstitute_rule({ 'type_id' => 'boolean', 'data' => true })
+        expect(Togls::Rules::Boolean).to receive(:new).with(:on, :boolean, true)
+        subject.reconstitute_rule({ 'id' => 'on', 'type_id' => 'boolean', 'data' => true })
       end
     end
 
     it 'returns the rule' do
       rule = double('rule')
       allow(::Togls.send(:rule_type_registry)).to receive(:get).with('boolean').and_return(Togls::Rules::Boolean)
-      allow(Togls::Rules::Boolean).to receive(:new).with(:boolean, true).and_return(rule)
-      expect(subject.reconstitute_rule({ 'type_id' => 'boolean', 'data' => true })).to eq(rule)
+      allow(Togls::Rules::Boolean).to receive(:new).with(:on, :boolean, true).and_return(rule)
+      expect(subject.reconstitute_rule({ 'id' => 'on', 'type_id' => 'boolean', 'data' => true })).to eq(rule)
     end
   end
 end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Togls::Rule do
   end
 
   describe "#id" do
-    it "returns the string representation of the id" do
+    it "returns the id" do
       rule = Togls::Rules::Boolean.new(:some_rule, :boolean, true)
       expect(rule.id).to eq(:some_rule)
     end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -23,21 +23,26 @@ RSpec.describe Togls::Rule do
   end
 
   describe '#initialize' do
+    it 'assigns the given id to an instance variable' do
+      rule = Togls::Rule.new(:some_rule, :hoopty, double, target_type: :foo)
+      expect(rule.instance_variable_get(:@id)).to eq(:some_rule)
+    end
+
     context 'when given initialization data' do
       context 'when given target type' do
         it 'assigns the given type_id to an instance variable' do
-          rule = Togls::Rule.new(:hoopty, double, target_type: :foo)
+          rule = Togls::Rule.new(:some_rule, :hoopty, double, target_type: :foo)
           expect(rule.instance_variable_get(:@type_id)).to eq(:hoopty)
         end
 
         it 'assigns the given data to an instance variable' do
           data = double('data')
-          rule = Togls::Rule.new(:hoopty, data, target_type: :foo)
+          rule = Togls::Rule.new(:some_rule, :hoopty, data, target_type: :foo)
           expect(rule.instance_variable_get(:@data)).to eq(data)
         end
 
         it 'assigns the given target type to an instance variable' do
-          rule = Togls::Rule.new(:hoopty, target_type: :some_target_type)
+          rule = Togls::Rule.new(:some_rule, :hoopty, target_type: :some_target_type)
           expect(rule.instance_variable_get(:@target_type)).to eq(:some_target_type)
         end
       end
@@ -46,7 +51,7 @@ RSpec.describe Togls::Rule do
         context 'when rule type did not set target type' do
           it 'raises target type missing exception' do
             expect {
-              rule = Togls::Rule.new(:hoopty)
+              rule = Togls::Rule.new(:some_rule, :hoopty)
             }.to raise_error(Togls::RuleMissingTargetType)
           end
         end
@@ -60,7 +65,7 @@ RSpec.describe Togls::Rule do
             end
 
             data = double('data')
-            rule = rule_klass.new(:hoopty, data)
+            rule = rule_klass.new(:some_rule, :hoopty, data)
             expect(rule.target_type).to eq(:foo)
           end
         end
@@ -70,12 +75,12 @@ RSpec.describe Togls::Rule do
     context 'when not given initialization data' do
       context 'when given target type' do
         it 'assigns the data instance variable to nil' do
-          rule = Togls::Rule.new(:hoopty, target_type: :foo)
+          rule = Togls::Rule.new(:some_rule, :hoopty, target_type: :foo)
           expect(rule.instance_variable_get(:@data)).to be_nil
         end
 
         it 'assigns the given target type to an instance variable' do
-          rule = Togls::Rule.new(:hoopty, target_type: :some_target_type)
+          rule = Togls::Rule.new(:some_rule, :hoopty, target_type: :some_target_type)
           expect(rule.instance_variable_get(:@target_type)).to eq(:some_target_type)
         end
       end
@@ -84,7 +89,7 @@ RSpec.describe Togls::Rule do
         context 'when rule type did not set target type' do
           it 'raises target type missing exception' do
             expect {
-              rule = Togls::Rule.new(:hoopty)
+              rule = Togls::Rule.new(:some_rule, :hoopty)
             }.to raise_error(Togls::RuleMissingTargetType)
           end
         end
@@ -97,7 +102,7 @@ RSpec.describe Togls::Rule do
               end
             end
 
-            rule = rule_klass.new(:hoopty)
+            rule = rule_klass.new(:some_rule, :hoopty)
             expect(rule.target_type).to eq(:foo)
           end
         end
@@ -107,37 +112,29 @@ RSpec.describe Togls::Rule do
 
   describe "#run" do
     it "raises NotImplemented exception" do
-      rule = Togls::Rule.new(:hoopty, target_type: :foo)
+      rule = Togls::Rule.new(:some_rule, :hoopty, target_type: :foo)
       expect { rule.run(double('feature key')) }
         .to raise_error(Togls::NotImplemented)
     end
   end
 
   describe "#id" do
-    it "gets the sha1 of the rule type_id, data, and target_type" do
-      rule = Togls::Rules::Boolean.new(:boolean, true)
-      expect(Togls::Helpers).to receive(:sha1).with(:boolean, true, Togls::TargetTypes::NONE)
-      rule.id
-    end
-
-    it "returns the sha1 it obtained" do
-      rule = Togls::Rules::Boolean.new(:boolean, true)
-      sha1 = double('sha1')
-      allow(Togls::Helpers).to receive(:sha1).and_return(sha1)
-      expect(rule.id).to eq(sha1)
+    it "returns the string representation of the id" do
+      rule = Togls::Rules::Boolean.new(:some_rule, :boolean, true)
+      expect(rule.id).to eq("some_rule")
     end
   end
 
   describe "#data" do
     it "returns the data it was initially initialized with" do
-      rule = Togls::Rule.new(:hoopty, "test value", target_type: :foo)
+      rule = Togls::Rule.new(:some_rule, :hoopty, "test value", target_type: :foo)
       expect(rule.data).to eq("test value")
     end
   end
 
   describe '#type_id' do
     it 'returns the type_it it was initialized with' do
-      rule = Togls::Rule.new(:hoopty, "test value", target_type: :foo)
+      rule = Togls::Rule.new(:some_rule, :hoopty, "test value", target_type: :foo)
       expect(rule.type_id).to eq(:hoopty)
     end
   end
@@ -145,7 +142,7 @@ RSpec.describe Togls::Rule do
   describe '#target_type' do
     context 'when the rule instance has a target type' do
       it 'returns the rule instances target type' do
-        rule = Togls::Rule.new(:jacked, target_type: :hoopty)
+        rule = Togls::Rule.new(:some_rule, :jacked, target_type: :hoopty)
         expect(rule.target_type).to eq(:hoopty)
       end
     end
@@ -159,7 +156,7 @@ RSpec.describe Togls::Rule do
             end
           end
 
-          rule = rule_klass.new(:jacked, 'some data')
+          rule = rule_klass.new(:some_rule, :jacked, 'some data')
           expect(rule.target_type).to eq(:woot_woot)
         end
       end
@@ -169,14 +166,14 @@ RSpec.describe Togls::Rule do
   describe '#missing_target_type?' do
     context 'when target type is set' do
       it 'returns false' do
-        rule = Togls::Rule.new(:hoopty, target_type: :foo)
+        rule = Togls::Rule.new(:some_rule, :hoopty, target_type: :foo)
         expect(rule.missing_target_type?).to eq(false)
       end
     end
 
     context 'when target type is not set' do
       it 'returns true' do
-        rule = Togls::Rule.new(:hoopty, target_type: :hoopty)
+        rule = Togls::Rule.new(:some_rule, :hoopty, target_type: :hoopty)
         rule.instance_variable_set(:@target_type, Togls::TargetTypes::NOT_SET)
         expect(rule.missing_target_type?).to eq(true)
       end
@@ -184,7 +181,7 @@ RSpec.describe Togls::Rule do
 
     context 'when target type is nil' do
       it 'returns true' do
-        rule = Togls::Rule.new(:hoopty, target_type: :hoopty)
+        rule = Togls::Rule.new(:some_rule, :hoopty, target_type: :hoopty)
         rule.instance_variable_set(:@target_type, nil)
         expect(rule.missing_target_type?).to eq(true)
       end

--- a/spec/togls/rule_spec.rb
+++ b/spec/togls/rule_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Togls::Rule do
   describe "#id" do
     it "returns the string representation of the id" do
       rule = Togls::Rules::Boolean.new(:some_rule, :boolean, true)
-      expect(rule.id).to eq("some_rule")
+      expect(rule.id).to eq(:some_rule)
     end
   end
 

--- a/spec/togls/rules/boolean_spec.rb
+++ b/spec/togls/rules/boolean_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Togls::Rules::Boolean do
 
   describe "#run" do
     it "returns the provided boolean value" do
-      bool_rule = Togls::Rules::Boolean.new(:boolean, true)
+      bool_rule = Togls::Rules::Boolean.new(:some_rule, :boolean, true)
       expect(bool_rule.run(double)).to eq(true)
     end
   end

--- a/spec/togls/rules/group_spec.rb
+++ b/spec/togls/rules/group_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Togls::Rules::Group do
   describe "#run" do
     context "when the target is included in the list" do
       it "returns true" do
-        group = Togls::Rules::Group.new(:group, ["target"], target_type: :foo)
+        group = Togls::Rules::Group.new(:some_group, :group, ["target"], target_type: :foo)
         expect(group.run(double('feature_key'), "target")).to eq(true)
       end
     end

--- a/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
 
         it "returns Togls::Rules::Boolean true toggle data" do
           expect(subject.get("some_toggle_id")).to eq({ "feature_id" => "some_toggle_id",
-                     "rule_id" => Togls::Rules::Boolean.new(:boolean, true).id })
+                     "rule_id" => Togls::Rules::Boolean.new(:on, :boolean, true).id })
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
 
         it "returns Togls::Rules::Boolean false toggle data" do
           expect(subject.get("some_toggle_id")).to eq({ "feature_id" => "some_toggle_id",
-                     "rule_id" => Togls::Rules::Boolean.new(:boolean, false).id })
+                     "rule_id" => Togls::Rules::Boolean.new(:off, :boolean, false).id })
         end
       end
 

--- a/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
+++ b/spec/togls/toggle_repository_drivers/env_override_driver_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
 
         it "returns Togls::Rules::Boolean true toggle data" do
           expect(subject.get("some_toggle_id")).to eq({ "feature_id" => "some_toggle_id",
-                     "rule_id" => Togls::Rules::Boolean.new(:on, :boolean, true).id })
+                     "rule_id" => Togls::Rules::Boolean.new(:on, :boolean, true).id.to_s })
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe Togls::ToggleRepositoryDrivers::EnvOverrideDriver do
 
         it "returns Togls::Rules::Boolean false toggle data" do
           expect(subject.get("some_toggle_id")).to eq({ "feature_id" => "some_toggle_id",
-                     "rule_id" => Togls::Rules::Boolean.new(:off, :boolean, false).id })
+                     "rule_id" => Togls::Rules::Boolean.new(:off, :boolean, false).id.to_s })
         end
       end
 

--- a/spec/togls/toggle_repository_spec.rb
+++ b/spec/togls/toggle_repository_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Togls::ToggleRepository do
       feature = Togls::Feature.new("some_feature_key", "Some Feature Desc", :hoopty)
       toggle = Togls::Toggle.new(feature)
       expect(subject.extract_storage_payload(toggle))
-        .to eq({ "feature_id" => "some_feature_key", "rule_id" => "e37f6204963d58a33ee8e261aed6fd395dbf2cd6" })
+        .to eq({ "feature_id" => "some_feature_key", "rule_id" => "off" })
     end
   end
 

--- a/spec/togls/toggle_spec.rb
+++ b/spec/togls/toggle_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Togls::Toggle do
               :hoopty
             end
           end
-          rule = rule_klass.new(:hoopty)
+          rule = rule_klass.new(:some_rule, :hoopty)
           allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
@@ -89,7 +89,7 @@ RSpec.describe Togls::Toggle do
               :hoopty
             end
           end
-          rule = rule_klass.new(:hoopty)
+          rule = rule_klass.new(:some_rule, :hoopty)
           allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           result = toggle.target_matches?(rule)
@@ -108,7 +108,7 @@ RSpec.describe Togls::Toggle do
               Togls::TargetTypes::NONE
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql true
@@ -126,7 +126,7 @@ RSpec.describe Togls::Toggle do
               :foo
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           expect(Togls.logger).to receive(:warn).with("Feature (key: #{feature.key}) cannot have target type of :not_set when rule (id: #{rule.id}) specifies a target type (target_type: #{rule.target_type}")
           toggle.target_matches?(rule)
@@ -143,7 +143,7 @@ RSpec.describe Togls::Toggle do
               :foo
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql false
@@ -162,7 +162,7 @@ RSpec.describe Togls::Toggle do
               Togls::TargetTypes::NONE
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql true
@@ -179,7 +179,7 @@ RSpec.describe Togls::Toggle do
               :foo
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql false
@@ -196,7 +196,7 @@ RSpec.describe Togls::Toggle do
               :foo
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
           allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
@@ -213,7 +213,7 @@ RSpec.describe Togls::Toggle do
               :hoopty
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
           allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           result = toggle.target_matches?(rule)
@@ -233,7 +233,7 @@ RSpec.describe Togls::Toggle do
               Togls::TargetTypes::NONE
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql true
@@ -250,7 +250,7 @@ RSpec.describe Togls::Toggle do
               :foo
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql true
@@ -267,7 +267,7 @@ RSpec.describe Togls::Toggle do
               :foo
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
           allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           expect(Togls.logger).to receive(:warn).with("Rule (id: #{rule.id}) cannot have target type of :not_set")
@@ -284,7 +284,7 @@ RSpec.describe Togls::Toggle do
               :foo
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
           allow(rule_klass).to receive(:target_type).and_return(Togls::TargetTypes::NOT_SET)
 
           result = toggle.target_matches?(rule)
@@ -302,7 +302,7 @@ RSpec.describe Togls::Toggle do
               :bar
             end
           end
-          rule = rule_klass.new(:sometypeid)
+          rule = rule_klass.new(:some_rule, :sometypeid)
 
           result = toggle.target_matches?(rule)
           expect(result).to eql false
@@ -373,7 +373,7 @@ RSpec.describe Togls::Toggle do
       context 'when the target is not nil' do
         it 'succeeds at validating' do
           feature = Togls::Feature.new(:name, 'desc', :foo)
-          rule = Togls::Rule.new(:sometypeid, target_type: :foo)
+          rule = Togls::Rule.new(:some_rule, :sometypeid, target_type: :foo)
           toggle = Togls::Toggle.new(feature)
           toggle.rule = rule
           expect {
@@ -385,7 +385,7 @@ RSpec.describe Togls::Toggle do
       context 'when the target is nil' do
         it 'raises an exception' do
           feature = Togls::Feature.new(:name, 'desc', :foo)
-          rule = Togls::Rule.new(:sometypeid, target_type: :foo)
+          rule = Togls::Rule.new(:some_rule, :sometypeid, target_type: :foo)
           toggle = Togls::Toggle.new(feature)
           toggle.rule = rule
           expect {

--- a/spec/togls/toggler_spec.rb
+++ b/spec/togls/toggler_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Togls::Toggler do
       it "creates a new rule" do
         allow(toggle_repository).to receive(:store)
         allow(toggle).to receive(:rule=)
-        expect(Togls::Rules::Boolean).to receive(:new).once.and_return(Togls::Rules::Boolean.new(:boolean))
+        expect(Togls::Rules::Boolean).to receive(:new).once.and_return(Togls::Rules::Boolean.new(:on, :boolean, true))
         subject.on
       end
     end
 
     it "sets the toggle's rule to the new rule" do
-      rule = Togls::Rules::Boolean.new(:boolean)
+      rule = Togls::Rules::Boolean.new(:off, :boolean, true)
       toggle_repository = subject.instance_variable_get(:@toggle_repository)
       allow(toggle_repository).to receive(:store)
       allow(Togls::Rules::Boolean).to receive(:new).and_return(rule)
@@ -72,7 +72,7 @@ RSpec.describe Togls::Toggler do
         toggle_repository = subject.instance_variable_get(:@toggle_repository)
         allow(toggle_repository).to receive(:store)
         allow(toggle).to receive(:rule=)
-        expect(Togls::Rules::Boolean).to receive(:new).with(:boolean, false)
+        expect(Togls::Rules::Boolean).to receive(:new).with(:off, :boolean, false)
         subject.off
       end
     end

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Togl" do
 
       data = double('some data')
 
-      rule = Togls.rule(:rule_id, data, target_type: :some_target_type)
+      rule = Togls.rule(:some_rule, :rule_id, data, target_type: :some_target_type)
       expect(rule).to be_a(FooBarRule)
       expect(rule.data).to eq(data)
       expect(rule.target_type).to eq(:some_target_type)
@@ -212,7 +212,7 @@ RSpec.describe "Togl" do
     it "creates a new feature with a rule" do
       Togls.default_feature_target_type Togls::TargetTypes::NONE
       Togls.release do
-        rule = Togls.rule(:boolean, false)
+        rule = Togls.rule(:off, :boolean, false)
         feature(:test, "some human readable description").on(rule)
       end
 
@@ -221,7 +221,7 @@ RSpec.describe "Togl" do
 
     it "creates a new feature with a group" do
       Togls.release do
-        rule = Togls.rule(:group, ["someone"], target_type: :foo)
+        rule = Togls.rule(:some_rule, :group, ["someone"], target_type: :foo)
         feature(:test, "some human readable description", target_type: :foo).on(rule)
       end
 
@@ -253,7 +253,7 @@ RSpec.describe "Togl" do
           register(:some_rule_type, FooBarRule)
         end
 
-        some_rule = Togls.rule(:some_rule_type)
+        some_rule = Togls.rule(:some_rule, :some_rule_type)
 
         expect {
           Togls.release do
@@ -287,7 +287,7 @@ RSpec.describe "Togl" do
           register(:some_rule_type, FooBarRule)
         end
 
-        some_rule = Togls.rule(:some_rule_type)
+        some_rule = Togls.rule(:some_rule, :some_rule_type)
 
         Togls.release do
           feature(:hoopty, 'some hoopty description', target_type: :purple_person).on(some_rule)
@@ -440,8 +440,8 @@ RSpec.describe "Togl" do
           register(:another_rule_type, AnotherRule)
         end
 
-        some_rule = Togls.rule(:some_rule_type)
-        a = Togls.rule(:another_rule_type)
+        some_rule = Togls.rule(:some_rule, :some_rule_type)
+        a = Togls.rule(:some_other_rule, :another_rule_type)
 
         Togls.release do
           feature(:hoopty, 'some hoopty description', target_type: :purple_person).on(some_rule)
@@ -464,7 +464,7 @@ RSpec.describe "Togl" do
     context 'when the feature target type claims to send a target' do
       context 'when the feature evaluation sends a target' do
         it 'can be correctly evaluated' do
-          numbers = Togls.rule(:group, [1,3,5], target_type: :number)
+          numbers = Togls.rule(:some_rule, :group, [1,3,5], target_type: :number)
           Togls.release do
             feature(:foo, 'desc', target_type: :number).on(numbers)
           end
@@ -481,7 +481,7 @@ RSpec.describe "Togl" do
 
       context 'when the feature evaluation does NOT sends a target' do
         it 'raises an exception' do
-          numbers = Togls.rule(:group, [1,3,5], target_type: :number)
+          numbers = Togls.rule(:some_rule, :group, [1,3,5], target_type: :number)
           Togls.release do
             feature(:foo, 'desc', target_type: :number).on(numbers)
           end
@@ -654,7 +654,7 @@ RSpec.describe "Togl" do
       Togls.rule_types do
         register(:my_rule_type, FooBarRule)
       end
-      rule = Togls.rule(:my_rule_type)
+      rule = Togls.rule(:my_rule, :my_rule_type)
 
       Togls.default_feature_target_type Togls::TargetTypes::NONE
       Togls.release do


### PR DESCRIPTION
Why you made the change:

I did this so that rules would exist and be identified by an abstract identifier
while still being modified.