### PR TITLE
Replace logger with optional logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Changed`: `Togls.logger` over to the `optional_logger` gem
 * `Changed`: Rules to be identified by an abstract given string id
 * `Changed`: Rule and Rule Type management to be global under Togls
 * `Changed`: The testing interface to allow for contract enforcement in tests

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -1,3 +1,4 @@
+require 'optional_logger'
 require 'togls/version'
 require 'togls/errors'
 require 'togls/helpers'
@@ -24,7 +25,6 @@ require 'togls/toggle'
 require 'togls/null_toggle'
 require 'togls/rule'
 require 'togls/rules'
-require 'logger'
 require 'togls/rule_manager'
 require 'togls/feature_toggle_registry_manager'
 require 'togls/default_feature_target_type_manager'
@@ -34,6 +34,7 @@ require 'togls/default_feature_target_type_manager'
 # Togls is the primary interface to the out of the box toggle registry. It is
 # the namespace the DSL is exposed under.
 module Togls
+  include OptionalLogger::LoggerManagement
   include RuleManager
   include FeatureToggleRegistryManager
   include DefaultFeatureTargetTypeManager

--- a/lib/togls/feature_toggle_registry_manager.rb
+++ b/lib/togls/feature_toggle_registry_manager.rb
@@ -28,10 +28,6 @@ module Togls
         Toggler.new(release_toggle_registry.instance_variable_get(:@toggle_repository), release_toggle_registry.get(key))
       end
 
-      def logger
-        @logger ||= Logger.new(STDOUT)
-      end
-
       def enable_test_mode
         @previous_release_toggle_registry = @release_toggle_registry
         @release_toggle_registry = test_toggle_registry

--- a/spec/togls/feature_toggle_registry_manager_spec.rb
+++ b/spec/togls/feature_toggle_registry_manager_spec.rb
@@ -44,16 +44,6 @@ RSpec.describe Togls::FeatureToggleRegistryManager do
     end
   end
 
-  describe ".logger" do
-    it "memoizes a new logger instance" do
-      logger = double('logger')
-      klass.instance_variable_set(:@logger, nil)
-      allow(Logger).to receive(:new).with(STDOUT).and_return(logger)
-      expect(klass.logger).to eq(logger)
-      expect(klass.logger).to eq(logger)
-    end
-  end
-
   describe '.enable_test_mode' do
     it 'stores the current release toggle registry' do
       test_registry = double('test registry')

--- a/spec/togls_spec.rb
+++ b/spec/togls_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe "Togl" do
     end
   end
 
+  describe 'logger management' do
+    it 'sets the logger' do
+      Togls.logger Logger.new(STDOUT)
+    end
+
+    it 'gets the logger' do
+      logger = Logger.new(STDOUT)
+      optional_logger = Togls.logger logger
+      expect(optional_logger).to be_a(OptionalLogger::Logger)
+      expect(optional_logger.wrapped_logger).to eq(logger)
+    end
+  end
+
   describe 'registering rule types' do
     it 'registers the rule type' do
       rule_klass = Class.new(Togls::Rule) do

--- a/togls.gemspec
+++ b/togls.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'optional_logger', '~> 1.1'
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.5'


### PR DESCRIPTION
I did this so that we could log safely using an application controlled logger vs the hard coded STDOUT logger we had before with the default log level.