### PR TITLE
Upgrade optional_logger to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that you can set version constraints properly.
 
 #### [Unreleased] - now
 
+* `Changed`: `optional_logger` to v2.0.0
+
 #### [v3.0.0] - 2016-10-19
 
 * `Changed`: `Togls.logger` over to the `optional_logger` gem

--- a/lib/togls.rb
+++ b/lib/togls.rb
@@ -34,7 +34,7 @@ require 'togls/default_feature_target_type_manager'
 # Togls is the primary interface to the out of the box toggle registry. It is
 # the namespace the DSL is exposed under.
 module Togls
-  include OptionalLogger::LoggerManagement
+  extend OptionalLogger::LoggerManagement
   include RuleManager
   include FeatureToggleRegistryManager
   include DefaultFeatureTargetTypeManager

--- a/togls.gemspec
+++ b/togls.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'optional_logger', '~> 1.1'
+  spec.add_dependency 'optional_logger', '~> 2.0'
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.5'


### PR DESCRIPTION
Why you made the change:

I did this so that we are using the latest stable release of
optional_logger. Even though this was a major bump for optional_logger
it doesn't change the interface that we expose at all. Therefore, it is
just a minor version bump.